### PR TITLE
Simplify linter conditions and skip trivy in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# github-build --organization Cloud-Officer --skip_slack --skip_license_check
+# github-build --organization Cloud-Officer --skip_slack --skip_license_check --ignored_linters trivy
 ---
 name: Build
 'on':
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
     timeout-minutes: 30
     steps:
     - name: Actionlint
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
     timeout-minutes: 30
     steps:
     - name: Markdownlint
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
     timeout-minutes: 30
     steps:
     - name: Yamllint


### PR DESCRIPTION
## Summary

Simplify the GitHub Actions build workflow by removing the `pull_request_target` event from linter job conditions and adding the `--ignored_linters trivy` flag to the build configuration comment.

**Key changes:**
- Add `--ignored_linters trivy` to the `github-build` configuration comment in `.github/workflows/build.yml`
- Remove `pull_request_target` from the `if` conditions of the `actionlint`, `markdownlint`, and `yamllint` jobs, keeping only `pull_request`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Build configuration change only, no application logic affected
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
