### PR TITLE
Migrate markdownlint to cli2 format and expand linter ignore paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 
 .github/                 @ydesgagn
 .gitignore               @ydesgagn
-.markdownlint.yml        @ydesgagn
+.markdownlint-cli2.yaml  @ydesgagn
 .yamllint.yml            @ydesgagn

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,25 @@
+globs:
+  - "**/*.md"
+  - "!.*"
+  - "!**/vendor/**"
+  - "!**/node_modules/**"
+  - "!**/Libraries/**"
+  - "!**/Pods/**"
+  - "!**/.build/**"
+  - "!**/Carthage/**"
+  - "!**/DerivedData/**"
+  - "!**/venv/**"
+  - "!**/.venv/**"
+  - "!**/dist/**"
+  - "!**/build/**"
+  - "!**/target/**"
+config:
+  default: true
+  first-line-heading: false
+  line-length: false
+  no-duplicate-heading: false
+  single-h1: false
+  tables: false
+  no-inline-html:
+    allowed_elements:
+      - br

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,9 +1,0 @@
-default: true
-first-line-heading: false
-line-length: false
-no-duplicate-heading: false
-single-h1: false
-tables: false
-no-inline-html:
-  allowed_elements:
-    - br

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,5 +5,20 @@ rules:
 ignore: |
   node_modules/
   vendor/
+  .build/
+  Pods/
+  Carthage/
+  DerivedData/
+  venv/
+  .venv/
+  .bundle/
+  .gradle/
+  .m2/
+  dist/
+  build/
+  target/
+  .npm/
+  .yarn/
+  .pnpm/
   tmp/
   var/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ This plugin provides development workflow automation for Claude Code.
 * Translation asset management via Loco (localise.biz) API
 * Firebase Crashlytics crash analysis via BigQuery
 
-## Prerequisites
+## Installation
+
+### Prerequisites
 
 Some skills require external CLI tools to be installed and authenticated:
 
@@ -37,8 +39,6 @@ Some skills require external CLI tools to be installed and authenticated:
 | `crashlytics` | [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) (`bq` CLI) | `gcloud auth application-default login` and set `BQ_*` env vars |
 | `query-db` / `analyze-db` | Database CLI (`mysql`, `psql`, `mongosh`, `redis-cli`, or `curl` for Elasticsearch) | Install the relevant client and set connection env vars |
 | `loco` | `curl`, `jq` | Set `LOCO_API_KEY_*` env vars |
-
-## Installation
 
 ```bash
 /plugin marketplace add cloud-officer/claude-code-plugin-dev


### PR DESCRIPTION
## Summary

Migrate the markdownlint configuration from `.markdownlint.yml` to the `.markdownlint-cli2.yaml` format and expand ignore paths for both markdownlint and yamllint to cover common build/dependency directories.

**Key changes:**
- Replace `.markdownlint.yml` with `.markdownlint-cli2.yaml`, adding glob patterns to exclude vendor, build, and dependency directories
- Expand `.yamllint.yml` ignore list with common directories (Pods, Carthage, DerivedData, venv, dist, build, target, package manager caches, etc.)
- Update `.github/CODEOWNERS` to reference the new `.markdownlint-cli2.yaml` filename
- Restructure `README.md` to nest Prerequisites under Installation as a subsection

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration-only changes to linter configs and documentation
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
