### PR TITLE
Add MCP permission docs and shell script linting rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,50 @@ Some skills require additional CLI tools:
 /plugin install co-dev@cloud-officer
 ```
 
+#### Recommended Permissions
+
+This plugin bundles several MCP servers. By default, Claude Code will prompt for permission each time an MCP tool is called. To auto-approve these tools, add the following entries to the `permissions.allow` array in your `~/.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__appstore__*",
+      "mcp__aws__*",
+      "mcp__context7__*",
+      "mcp__fetch__*",
+      "mcp__gcloud__*",
+      "mcp__github__*",
+      "mcp__mongodb__*",
+      "mcp__mysql__*",
+      "mcp__playstore__*",
+      "mcp__postgres__*",
+      "mcp__redis__*"
+    ]
+  }
+}
+```
+
+If you also use remote MCP servers (see [Remote MCP Servers](#remote-mcp-servers-optional)), add their patterns too:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__atlassian__*",
+      "mcp__bigquery__*",
+      "mcp__figma__*",
+      "mcp__newrelic__*",
+      "mcp__paypal__*",
+      "mcp__stripe__*",
+      "mcp__vercel__*"
+    ]
+  }
+}
+```
+
+**Note:** These entries merge with your existing `allow` list — you don't need to replace it. Only add entries for the MCP servers you actually use.
+
 ## Usage
 
 ### Commands

--- a/skills/run-linters/SKILL.md
+++ b/skills/run-linters/SKILL.md
@@ -121,3 +121,39 @@ Do NOT add these patterns to bypass linting:
 ```
 
 If you encounter an issue that seems unfixable, explain the problem to the user and ask how they want to proceed.
+
+## Shell Script Linting Rules (SL0001, SL0002)
+
+When fixing shell script lint errors (e.g., from `shellcheck` or custom shell linters), apply these rules:
+
+### SL0001: Variables must use braces
+
+Always wrap shell variables in `${}` braces. This prevents ambiguity and word-splitting bugs.
+
+```bash
+# Bad
+echo "$HOME/.local/bin:$PATH"
+if [ "$CURRENT_BRANCH" != "$MASTER_BRANCH" ]; then
+
+# Good
+echo "${HOME}/.local/bin:${PATH}"
+if [ "${CURRENT_BRANCH}" != "${MASTER_BRANCH}" ]; then
+```
+
+### SL0002: Use `==` instead of `=` for string comparison
+
+In `[` and `[[` test expressions, use `==` for string equality, not `=`.
+
+```bash
+# Bad
+if [ "${CONFIGURATION}" = "Debug" ]; then
+
+# Good
+if [ "${CONFIGURATION}" == "Debug" ]; then
+```
+
+### General Shell Script Fixes
+
+- **Quote all variable expansions** — `"${VAR}"` not `$VAR`
+- **Use `[[` over `[` when possible** — safer, supports `&&`, `||`, pattern matching
+- **Use `$(command)` over backticks** — `` `command` `` is deprecated


### PR DESCRIPTION
## Summary

Add documentation for recommended MCP server permissions and extend the run-linters skill with shell script linting guidance.

**Key changes:**
- Add "Recommended Permissions" section to README.md with `permissions.allow` patterns for bundled and remote MCP servers
- Add shell script linting rules (SL0001, SL0002) to the run-linters skill covering brace-wrapped variables and `==` for string comparison
- Add general shell script best practices (quoting, `[[` over `[`, `$(command)` over backticks)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation and skill definition changes only
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
