### PR TITLE
Add Install Plugin heading and fix heading level in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,14 @@ Some skills require additional CLI tools:
 | `newrelic` (fallback) | [New Relic CLI](https://github.com/newrelic/newrelic-cli) | `brew install newrelic-cli && newrelic profile add` |
 | `heroku` (fallback) | [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) | `brew install heroku && heroku login` |
 
+### Install Plugin
+
 ```bash
 /plugin marketplace add cloud-officer/claude-code-plugin-dev
 /plugin install co-dev@cloud-officer
 ```
 
-#### Recommended Permissions
+### Recommended Permissions
 
 This plugin bundles several MCP servers. By default, Claude Code will prompt for permission each time an MCP tool is called. To auto-approve these tools, add the following entries to the `permissions.allow` array in your `~/.claude/settings.json`:
 


### PR DESCRIPTION
## Summary

Improve the README installation section by adding a missing heading above the plugin install commands and normalizing the heading hierarchy so sibling sections use the same level.

**Key changes:**

- Add `### Install Plugin` heading above the `/plugin marketplace add` and `/plugin install` commands
- Promote `#### Recommended Permissions` to `### Recommended Permissions` for consistent heading hierarchy

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
