### PR TITLE
Add marketplace.json to enable /plugin marketplace install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "cloud-officer",
+  "owner": {
+    "name": "Cloud Officer",
+    "email": "info@cloudofficer.ca"
+  },
+  "plugins": [
+    {
+      "name": "co-dev",
+      "source": ".",
+      "description": "Cloud Officer development workflow tools for PR management, issue tracking, code quality, cloud infrastructure (AWS, GCP), deployment (Vercel, Heroku), payments (Stripe, PayPal), observability (New Relic), design (Figma), app stores (App Store Connect, Google Play), and database management",
+      "version": "1.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The README instructs users to install this plugin via `/plugin marketplace add cloud-officer/claude-code-plugin-dev` followed by `/plugin install co-dev@cloud-officer`, but the first command fails because the repo has no `.claude-plugin/marketplace.json`. Claude Code's marketplace flow requires a marketplace manifest in the repo it is asked to add. This PR adds a single-plugin marketplace manifest that names the marketplace `cloud-officer` and lists `co-dev` (with `source: "."`) as its sole plugin, making the documented install commands work end-to-end without any change to the README.

**Key changes:**

- Add `.claude-plugin/marketplace.json` declaring the `cloud-officer` marketplace with `co-dev` as an in-repo plugin (`source: "."`)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration manifest only; no executable code paths to cover.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified