### PR TITLE
Feat #16: Use git worktree instead of git checkout in work-issue workflow

### DIFF
--- a/commands/work-issue.md
+++ b/commands/work-issue.md
@@ -106,18 +106,42 @@ Steps 4–6 and 8 are gated by Issue Type (detected above). The gating column on
 
    **If no Figma links are found or Figma MCP is unavailable, skip this step.**
 
-3. **Prepare repository** (all types)
+3. **Prepare an isolated worktree** (all types)
+
+   This step uses `git worktree` instead of `git checkout -b`. Worktrees give each issue its own working directory, so any uncommitted work in the user's main checkout is left untouched and multiple issues can be in flight in parallel.
 
    ```bash
    DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+   REPO_ROOT=$(git rev-parse --show-toplevel)
+   cd "$REPO_ROOT"
    git fetch --all
-   git checkout $DEFAULT_BRANCH
-   git pull origin $DEFAULT_BRANCH
+   ```
+
+   Decide the branch name from the issue tracker:
+
+   - GitHub: `BRANCH=issue-$ARGUMENTS`
+   - Jira: `BRANCH=$ARGUMENTS` (uppercase — matches the Jira key)
+
+   Ensure `.worktrees/` is gitignored in the target repo. If it isn't, add and commit the change before creating the worktree (otherwise the worktree contents would pollute `git status`):
+
+   ```bash
+   if ! git check-ignore -q .worktrees 2>/dev/null; then
+     echo ".worktrees/" >> .gitignore
+     git add .gitignore && git commit -m "Ignore .worktrees/ directory"
+   fi
+   ```
+
+   Create the worktree on a new branch based on the **latest** default branch (not the user's current `HEAD`):
+
+   ```bash
+   git worktree add ".worktrees/$BRANCH" -b "$BRANCH" "origin/$DEFAULT_BRANCH"
+   cd ".worktrees/$BRANCH"
    git submodule update --init --recursive
    ```
 
-   - GitHub: `git checkout -b issue-$ARGUMENTS`
-   - Jira: `git checkout -b $ARGUMENTS` (uppercase)
+   All subsequent steps (exploration, edits, commit, push, PR) run from inside `.worktrees/$BRANCH`. The user's main checkout is untouched.
+
+   **Note for Claude Code users:** `claude --worktree <name>` provides a similar isolated-workspace flow at the harness level. This command intentionally manages the worktree itself so the workflow is portable across CLI invocations.
 
 4. **Codebase exploration** (Feature: required · Task: if non-trivial · Bug: skip)
 
@@ -212,9 +236,19 @@ Steps 4–6 and 8 are gated by Issue Type (detected above). The gating column on
 
 11. **Cleanup** (all types)
 
-    ```bash
-    git checkout $DEFAULT_BRANCH
-    ```
+    Two options — ask the user which they want, defaulting to **keep** so they can inspect or continue iterating:
+
+    - **Keep the worktree** (default): just `cd "$REPO_ROOT"` to return to the main checkout. The worktree at `.worktrees/$BRANCH` stays put for follow-up work.
+    - **Remove the worktree** (if the PR has merged or the work is abandoned):
+
+      ```bash
+      cd "$REPO_ROOT"
+      git worktree remove ".worktrees/$BRANCH"
+      # If the worktree has uncommitted changes, `git worktree remove` will refuse.
+      # Confirm with the user before forcing: `git worktree remove --force ".worktrees/$BRANCH"`
+      ```
+
+    The local branch is preserved either way. Delete it explicitly with `git branch -D "$BRANCH"` once the PR is merged.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Closes #16. Replaces the `git checkout -b` branching strategy in `commands/work-issue.md` Step 3 with `git worktree add`, so each issue gets its own isolated working directory. The user's main checkout is no longer disrupted by `git fetch` + `git checkout` and multiple issues can be worked on in parallel without stashing.

**Key changes:**

- `commands/work-issue.md` Step 3 ("Prepare repository" → "Prepare an isolated worktree"): the new flow runs `git worktree add ".worktrees/$BRANCH" -b "$BRANCH" "origin/$DEFAULT_BRANCH"` instead of `git checkout -b`, then `cd`s into the worktree for the rest of the workflow.
- Added a pre-flight that ensures `.worktrees/` is gitignored in the target repo before creating the worktree (auto-adds + commits if missing) so worktree contents never pollute `git status`.
- Worktree is always based on the **freshly fetched** `origin/$DEFAULT_BRANCH`, never the user's current `HEAD` — this preserves the "always start from latest default" guarantee without needing to `checkout` the default branch in the user's main worktree.
- `submodule update --init --recursive` runs inside the new worktree (each worktree has its own submodule state).
- Step 11 (Cleanup) now offers two paths: keep the worktree (default — useful for follow-up review/iteration) or `git worktree remove ".worktrees/$BRANCH"` once the PR has merged. Force-remove only with explicit user confirmation.
- Added a note pointing users at the harness-level `claude --worktree <name>` flag as an alternative for whole-session isolation.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: command files are markdown specs; this repo has no automated test framework. Verified with `linters` (0 errors) and a manual read of the new Step 3 / Step 11 against the rest of the workflow.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified