### PR TITLE
Grant issues: write permission in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,6 +9,7 @@ name: Auto-merge for code owners
     - synchronize
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 jobs:
   enable_automerge:


### PR DESCRIPTION
## Summary

Adds the `issues: write` permission to the auto-merge GitHub Actions workflow so the job can interact with issue-scoped APIs (e.g., commenting on or updating linked issues) when enabling auto-merge for code owners.

**Key changes:**

- Add `issues: write` to the `permissions` block in `.github/workflows/auto-merge.yml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): CI/CD workflow permission update

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Workflow permission change validated by GitHub Actions runtime; no application code affected.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
