### PR TITLE
Remove auto-merge enable step from auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -77,10 +77,3 @@ jobs:
       env:
         GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
         PR: "${{github.event.pull_request.number}}"
-    - name: Enable auto-merge
-      shell: bash
-      if: steps.check.outputs.is_owner == 'true'
-      run: gh pr merge --auto --squash "$PR"
-      env:
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
-        PR: "${{github.event.pull_request.number}}"


### PR DESCRIPTION
## Summary

Removes the `Enable auto-merge` step from the `auto-merge` GitHub Actions workflow. Auto-merge will no longer be enabled automatically by this workflow when the PR author is recognized as an owner; the preceding ownership check step is retained, but the subsequent `gh pr merge --auto --squash` invocation has been dropped.

**Key changes:**

- Removed the `Enable auto-merge` step (and its `GH_TOKEN`/`PR` env block) from `.github/workflows/auto-merge.yml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Workflow file change with no executable code paths to unit-test; behavior is verified by GitHub Actions runtime.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
