### PR TITLE
Update CODEOWNERS to team, switch auto-merge to PAT, ignore code-review.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*                        @ydesgagn
+*                        @Cloud-Officer/Maintainers
 
 # build/deploy related files
 
-.github/                 @ydesgagn
-.gitignore               @ydesgagn
-.markdownlint-cli2.yaml  @ydesgagn
-.yamllint.yml            @ydesgagn
+.github/                 @Cloud-Officer/Maintainers
+.gitignore               @Cloud-Officer/Maintainers
+.markdownlint-cli2.yaml  @Cloud-Officer/Maintainers
+.yamllint.yml            @Cloud-Officer/Maintainers

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -75,5 +75,5 @@ jobs:
       if: steps.check.outputs.is_owner == 'true'
       run: gh pr review --approve "$PR"
       env:
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+        GH_TOKEN: "${{secrets.GH_BOT_PAT}}"
         PR: "${{github.event.pull_request.number}}"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,6 +13,7 @@ globs:
   - "!**/dist/**"
   - "!**/build/**"
   - "!**/target/**"
+  - "!docs/code-review.md"
 config:
   default: true
   first-line-heading: false


### PR DESCRIPTION
## Summary

Adjusts repository ownership, CI auto-merge auth, and markdown lint scope.

**Key changes:**

- `.github/CODEOWNERS`: replace individual owner `@ydesgagn` with team `@Cloud-Officer/Maintainers` for all paths (root, `.github/`, `.gitignore`, `.markdownlint-cli2.yaml`, `.yamllint.yml`)
- `.github/workflows/auto-merge.yml`: use `GH_BOT_PAT` instead of the default `GITHUB_TOKEN` for the approve step so auto-merge approvals come from the bot account
- `.markdownlint-cli2.yaml`: exclude `docs/code-review.md` from markdown linting (generated review output)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: configuration-only changes (CODEOWNERS, workflow token, lint ignore)
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified