### PR TITLE
Drop cpan from Linux and Windows language server install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ npx playwright install chromium
 Optional service CLIs: each tool ships its own Linux installer — see official docs for `aws`, `gcloud`, `heroku`,
 `stripe`, `vercel`, `newrelic`, `jira-cli`. App Store Connect is macOS-only.
 
-Language servers (LSPs): the `npm`, `gem`, `go install`, `rustup`, and
-`cpan` install commands listed under the macOS section are cross-platform. Use your distro's package manager for
+Language servers (LSPs): the `npm`, `gem`, `go install`, and `rustup`
+install commands listed under the macOS section are cross-platform. Use your distro's package manager for
 `clangd` (often `clang-tools` or `llvm`) and `pyright` (or
 `pip install pyright`). Swift LSP requires Xcode (macOS only).
 
@@ -182,8 +182,8 @@ npx playwright install chromium
 
 Optional service CLIs: install via `scoop`, `winget`, or each tool's installer. App Store Connect is macOS-only.
 
-Language servers (LSPs): the `npm`, `gem`, `go install`, `rustup`, and
-`cpan` install commands listed under the macOS section work on Windows under their respective toolchains. Use
+Language servers (LSPs): the `npm`, `gem`, `go install`, and `rustup`
+install commands listed under the macOS section work on Windows under their respective toolchains. Use
 `scoop install llvm` for `clangd`. Swift LSP is macOS-only (requires Xcode).
 
 ### Configure Remote MCPs (optional)


### PR DESCRIPTION
## Summary

Corrects the cross-platform language server (LSP) install guidance in the README. The `cpan` install command was incorrectly listed among the macOS commands described as cross-platform, but it is not part of the cross-platform set referenced by the Linux and Windows sections. This removes `cpan` from those notes so the instructions match what is actually supported.

**Key changes:**

- Remove `cpan` from the cross-platform LSP install list in the Linux section of `README.md`
- Remove `cpan` from the cross-platform LSP install list in the Windows section of `README.md`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change to the README
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified