### PR TITLE
Strengthen create-pr CI/test guidance and remove work-issue pre-PR review

### DIFF
--- a/commands/work-issue.md
+++ b/commands/work-issue.md
@@ -242,7 +242,7 @@ Steps 4–6 are gated by Issue Type (detected above) — the gating note on each
 
    1. **Find the project's test setup first — don't guess.** Detect the runner and conventions from the repo before writing anything:
       - Locate existing tests next to the code you changed (sibling `*_test.*`, `*_spec.*`, or a parallel `test/`, `tests/`, `spec/`, `__tests__/` tree).
-      - Identify the runner from the manifest/config (`package.json` scripts, `Gemfile` + `spec/`, `pytest.ini`/`pyproject.toml`, `go test`, `*.csproj`, etc.).
+      - Identify the runner from the manifest/config (`package.json` scripts, `Gemfile` + `spec/`, `pytest.ini`/`pyproject.toml`, `go test`, `*.csproj`, etc.). **For Swift/iOS:** `Package.swift` → `swift test`; `*.xcworkspace`/`*.xcodeproj` → `xcodebuild test -scheme <Scheme> -destination 'platform=iOS Simulator,name=iPhone 15'` (find schemes with `xcodebuild -list`). On macOS these run locally — do not treat an Xcode project as "untestable".
       - Match the nearest existing tests' style — naming, fixtures/factories, mocking approach, assertion library, file placement.
 
    2. **Write or update tests that cover the change.** Work from the same three sources as the QA checklist (step 12): the issue's objective, the nature of the change, and the blast radius. At minimum cover:
@@ -252,26 +252,13 @@ Steps 4–6 are gated by Issue Type (detected above) — the gating note on each
 
       For **Bug** fixes, write a regression test that **fails before the fix and passes after**, and state that you confirmed both.
 
-   3. **Run the tests and make them pass.** Run the narrow suite for the touched area first, then the broader suite if it is fast enough. Paste the final passing result. If the suite genuinely cannot run locally (missing services, etc.), say so explicitly and describe how you mitigated it — do not claim tests pass when you did not run them.
+   3. **Run the tests and make them pass.** Run the narrow suite for the touched area first, then the broader suite if it is fast enough. **Paste the runner's own pass marker** — `** TEST SUCCEEDED **` / `Test Suite '...' passed` (Xcode), `0 failures` (rspec), `N passed` (pytest), `ok` (go) — not a paraphrased "tests pass". The "can't run it locally" excuse is narrow: on macOS, `swift test` and `xcodebuild test` against the iOS Simulator DO run locally — a slow build or a missing `-scheme` is not a reason to skip, find the scheme and run it. Only the genuine absence of infrastructure on this machine (live external services, physical hardware) qualifies; say so explicitly and describe how you mitigated it. Never claim tests pass when you did not run them.
 
    4. **No-test exception — narrow and explicit.** A few change types have no unit-testable logic: pure copy/i18n, static assets, formatting-only changes, config/docs, or generated files. Only then may you skip tests, and you must tell the user **which** category applies and why. "It's hard to test" is not a valid reason — ask the user for guidance instead of skipping.
 
    If the project has no test harness at all, surface that to the user and propose adding a minimal one (or get explicit acknowledgement to proceed without) rather than silently shipping untested code.
 
-9. **Pre-PR review** (opt-in for all types)
-
-   Ask the user: **"Run a pre-PR review before creating the PR? (y/n)"**
-
-   If yes, launch 3 parallel agents over the staged + committed diff:
-   - **Simplicity/DRY:** duplication, dead abstractions, over-engineering, premature generalization
-   - **Bugs:** off-by-one, missing error handling, broken contracts, type confusion, edge cases
-   - **Conventions:** mismatch with codebase patterns, naming, file organization, test placement
-
-   Consolidate findings into a list ordered by severity. Present the highest-severity issues to the user and ask which to fix before the PR.
-
-   For a deeper, whole-codebase audit, point the user at `/code-review-deep` instead — it covers security, dependencies, infrastructure, and more.
-
-10. **Create PR** (all types — only when user explicitly requests)
+9. **Create PR** (all types — only when user explicitly requests)
 
     **Precondition — tests gate (step 8):** Do not create the PR unless step 8 is satisfied: tests covering the change exist and pass, *or* a stated no-test exception applies. If neither holds, go back and write the tests first.
 
@@ -286,7 +273,7 @@ Steps 4–6 are gated by Issue Type (detected above) — the gating note on each
     - NO footers, NO co-authors, NO "Generated with Claude Code" signatures
 
     **Open the PR via the `create-pr` skill:**
-    The `create-pr` skill takes care of pushing the branch, opening the PR, and switching the working tree back to the default branch when done. Do NOT run `git push` or `gh pr create` here — the skill does both.
+    The `create-pr` skill takes care of running the test suite locally before pushing, pushing the branch, opening the PR, **watching CI in the background (`gh pr checks --watch`, non-blocking)**, and switching the working tree back to the default branch when done. Do NOT run `git push` or `gh pr create` here — the skill does both. The task is not done until CI is green: if the background watch reports a failing GitHub Actions or Xcode Cloud check, fix it and push again before handing off. Read the checks with `gh pr checks` and act on its output — the token that just opened the PR can read that PR's checks.
 
     When invoking the skill, override its commit-message / PR-title defaults with the issue-tagged form:
 
@@ -319,7 +306,7 @@ Steps 4–6 are gated by Issue Type (detected above) — the gating note on each
 
     - GitHub: `mcp__github__add_issue_comment` (preferred) or `gh issue comment $ARGUMENTS --body "..."`
     - Jira: `mcp__atlassian__addCommentToJiraIssue` (preferred) or `jira issue comment add $ARGUMENTS "..."`
-    - Jira note: post this comment as part of (or right after) the move to **Code Review** in step 10, so testers picking up the ticket find the checklist waiting.
+    - Jira note: post this comment as part of (or right after) the move to **Code Review** in step 9, so testers picking up the ticket find the checklist waiting.
 
     ### Where the checks come from
 

--- a/commands/work-issue.md
+++ b/commands/work-issue.md
@@ -245,7 +245,7 @@ Steps 4–6 are gated by Issue Type (detected above) — the gating note on each
       - Identify the runner from the manifest/config (`package.json` scripts, `Gemfile` + `spec/`, `pytest.ini`/`pyproject.toml`, `go test`, `*.csproj`, etc.). **For Swift/iOS:** `Package.swift` → `swift test`; `*.xcworkspace`/`*.xcodeproj` → `xcodebuild test -scheme <Scheme> -destination 'platform=iOS Simulator,name=iPhone 15'` (find schemes with `xcodebuild -list`). On macOS these run locally — do not treat an Xcode project as "untestable".
       - Match the nearest existing tests' style — naming, fixtures/factories, mocking approach, assertion library, file placement.
 
-   2. **Write or update tests that cover the change.** Work from the same three sources as the QA checklist (step 12): the issue's objective, the nature of the change, and the blast radius. At minimum cover:
+   2. **Write or update tests that cover the change.** Work from the same three sources as the QA checklist (step 11): the issue's objective, the nature of the change, and the blast radius. At minimum cover:
       - the success path for each new or changed behavior;
       - the negative/failure paths (invalid input, missing data, permission denied, not-found, boundaries) — not just the happy path;
       - the regression surface — if you changed a shared function/component/query used in N places, add or extend tests so those callers stay covered.
@@ -294,13 +294,13 @@ Steps 4–6 are gated by Issue Type (detected above) — the gating note on each
 
     - Jira only: `mcp__atlassian__transitionJiraIssue` (preferred) or `jira issue move $ARGUMENTS "Code Review"`
 
-11. **Update issue if needed** (all types)
+10. **Update issue if needed** (all types)
     If the implementation differs from the original or additional context would be helpful, update the issue.
     Write in a prospective tone (as if before implementation, not after):
     - GitHub: `mcp__github__update_issue` (preferred) or `gh issue edit $ARGUMENTS --title "<updated title>" --body "<updated description>"`
     - Jira: `mcp__atlassian__editJiraIssue` (preferred) or `jira issue edit $ARGUMENTS --summary "<updated title>" --description "<updated description>"`
 
-12. **Post a tester QA checklist on the issue** (all types)
+11. **Post a tester QA checklist on the issue** (all types)
 
     Once the PR is open and the issue is updated, post a comment on the issue aimed at the **testers / QA team**. This is the hand-off gate right before the task moves through code review — it gives a tester an explicit, checkable list to confirm the work is *actually* done, not just merged.
 
@@ -346,7 +346,7 @@ Steps 4–6 are gated by Issue Type (detected above) — the gating note on each
 
     Write the comment in the **same language the issue itself is written in**. Detect that language *only* from the prose the reporter actually typed in the issue's title and description — the human sentences, not code identifiers or field labels. **Ignore every environmental signal**: the Jira/GitHub UI language, the browser or OS locale, the account's language setting, project defaults, and any prior assumption that "issues here are usually French." A French UI around an English issue body still means the comment must be English. If the title and body are in English, comment in English; if they're in French, comment in French. When the body is genuinely mixed or too short to tell, match the language of the title, then the longest prose block. Keep each item short and verifiable by a human who has not seen the diff.
 
-13. **Cleanup** (all types)
+12. **Cleanup** (all types)
 
     The cleanup depends on which path was taken in step 3.
 
@@ -380,4 +380,4 @@ Steps 4–6 are gated by Issue Type (detected above) — the gating note on each
 - Jira: Branch names must be UPPERCASE (matching Jira key format)
 - Use the correct commit prefix based on detected issue type (Bug → Fix, Feature → Feat, Task → no prefix)
 - GitHub: the PR **body** must include a closing keyword (`Closes`/`Fixes`/`Resolves #<n>`) so the issue auto-closes on merge — the `#<n>:` title prefix alone only links the issue, it does not close it
-- The tester QA checklist (step 12) is sourced from three things, not just one: the issue's objective (never a recap of the diff), the area/nature of the change (when the issue has no acceptance criteria), and the full blast radius (if changed code is reached from N places, all N must be checked). Cover negative paths, security, stress, and bad-network cases — not only the happy path — and help testers turn items into Given/When/Then test cases. Write it in the language the issue body is written in (detect from the reporter's own prose in the title/description — never from the Jira/GitHub UI language, browser/OS locale, or account settings; a French UI on an English issue still requires an English comment)
+- The tester QA checklist (step 11) is sourced from three things, not just one: the issue's objective (never a recap of the diff), the area/nature of the change (when the issue has no acceptance criteria), and the full blast radius (if changed code is reached from N places, all N must be checked). Cover negative paths, security, stress, and bad-network cases — not only the happy path — and help testers turn items into Given/When/Then test cases. Write it in the language the issue body is written in (detect from the reporter's own prose in the title/description — never from the Jira/GitHub UI language, browser/OS locale, or account settings; a French UI on an English issue still requires an English comment)

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-pr
 description: Create, open, submit, or prepare a pull request (PR). Generates the commit message, PR title, and PR body, opens the PR, then returns the repo to its default branch. Use when the user wants to create a PR, open a PR, submit a PR, make a PR, push a PR, send a PR, generate PR content, prepare a pull request, or fill a PR template from code changes.
-allowed-tools: Bash(git:*), Bash(gh:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(open:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Glob
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(open:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Bash(xcodebuild:*), Bash(swift:*), Bash(xcrun:*), Bash(npm:*), Bash(yarn:*), Bash(pnpm:*), Bash(bundle:*), Bash(pytest:*), Bash(go:*), Bash(dotnet:*), Read, Glob
 ---
 
 # Create Pull Request
@@ -93,13 +93,36 @@ git add -A
 git diff --cached --quiet || git commit -m "<commit message from Step 2>"
 ```
 
-## Step 4: Push the Branch
+## Step 4: Run Tests Locally (gate before pushing)
+
+Run the project's existing test suite before pushing. A red CI run that a local test would have caught is exactly what this step exists to prevent. **If a test harness exists and you have not run it, do not push.**
+
+**Step 4.1 — Detect the runner from the repo, including compiled/mobile stacks:**
+
+- JS/TS: `package.json` scripts → `npm test` / `yarn test` / `pnpm test`
+- Ruby: `Gemfile` + `spec/` → `bundle exec rspec`; `test/` → `bin/rails test`
+- Python: `pytest.ini` / `pyproject.toml` / `tox.ini` → `pytest`
+- Go: `go test ./...`
+- .NET: `*.csproj` / `*.sln` → `dotnet test`
+- **Swift / iOS (you are on macOS — these ARE runnable locally):**
+  - `Package.swift` (SwiftPM) → `swift test`
+  - `*.xcworkspace` / `*.xcodeproj` → `xcodebuild test -scheme <Scheme> -destination 'platform=iOS Simulator,name=iPhone 15'`
+    - List schemes with `xcodebuild -list -workspace <name>.xcworkspace` (or `-project <name>.xcodeproj`) and pick the app/test scheme.
+    - Use `-workspace` when a `.xcworkspace` exists (CocoaPods/SPM workspaces), otherwise `-project`.
+
+**Step 4.2 — Run the suite covering your changes and paste the runner's own pass marker as proof:**
+
+`** TEST SUCCEEDED **` / `Test Suite '...' passed` (Xcode), `0 failures` (rspec), `passed`/`N passed` (pytest), `ok` (go). A bare "tests pass" without the runner's output does not count. If anything fails, fix it **before** pushing — never push red.
+
+**Step 4.3 — The "can't run it locally" exception is narrow.** On macOS, `swift test` and `xcodebuild test` against the iOS Simulator run locally; "slow to build" or "needs a scheme" is not an excuse to skip — find the scheme and run it. Only skip when the suite needs infrastructure genuinely absent on this machine (live external services, physical hardware), and say so explicitly. If the repo has no test harness at all, state that and continue.
+
+## Step 5: Push the Branch
 
 ```bash
 git push -u origin "$CURRENT_BRANCH"
 ```
 
-## Step 5: Open the Pull Request
+## Step 6: Open the Pull Request
 
 Prefer `mcp__github__create_pull_request` when the GitHub MCP server is available. Otherwise use the GitHub CLI:
 
@@ -108,9 +131,32 @@ PR_URL=$(gh pr create --base "$DEFAULT_BRANCH" --head "$CURRENT_BRANCH" --title 
 open "$PR_URL"
 ```
 
-If a PR already exists for `$CURRENT_BRANCH` (e.g., the caller already opened it), `gh pr create` will fail — treat that as success and continue to Step 6.
+If a PR already exists for `$CURRENT_BRANCH` (e.g., the caller already opened it), `gh pr create` will fail — treat that as success and continue to Step 7.
 
-## Step 6: Return to Default Branch
+## Step 7: Monitor CI in the Background
+
+A pushed PR is not done until its checks are green — but CI (especially Xcode Cloud) can take several minutes, so **watch it without blocking the session**. Launch the watch as a background task, then continue straight to Step 8. The background watch re-invokes you when CI settles, so a failure is still caught and triaged in this session — just not by sitting idle.
+
+Run this with the Bash tool's **`run_in_background: true`** (do not foreground it):
+
+```bash
+gh pr checks "$CURRENT_BRANCH" --watch --fail-fast
+```
+
+`gh pr checks` reports **every** check registered on the PR — GitHub Actions **and Xcode Cloud**, which posts its build/test result back to GitHub as a check run. So this one command covers both CIs. (`--fail-fast` returns as soon as one check fails; drop it to wait for the full set.) The command exits non-zero if any check fails, zero if all pass.
+
+> **Reading the checks always works here — run `gh pr checks` and report what it returns.** The token that just pushed the branch and opened the PR has everything needed to read that PR's checks, so trust the command and let its output drive your next step. If it ever errors, surface the **verbatim** output and exit code so the real cause is visible. A 404/403 means the wrong working directory loaded the wrong per-repo token — `cd` into the PR's repo and retry.
+
+Do **not** wait on it before Step 8 — proceed immediately. When the background task completes:
+
+- **All checks green (exit 0):** report it; nothing more to do.
+- **A check fails (non-zero):** Step 8 has likely already returned you to the default branch, so re-checkout the PR branch first (`git checkout "$CURRENT_BRANCH"`), then pull the failing logs, fix the cause, and push again (re-run Steps 4–7). Do not leave the PR with a red required check.
+  - GitHub Actions: `gh run view --log-failed` (the failing run URL is also printed by `gh pr checks`).
+  - **Xcode Cloud:** the check tells you only pass/fail. For the failing test names and logs, use the `appstore` skill — `asc-mcp` does not expose the `ci*` endpoints, so the failing `.xcresult` must be fetched via the App Store Connect API and read with `xcrun xcresulttool`.
+
+If the repo has no CI configured, `gh pr checks` exits immediately with no checks — note that and continue.
+
+## Step 8: Return to Default Branch
 
 Leave the repo on the default branch so the user is back at a clean starting point:
 
@@ -192,4 +238,6 @@ If the section is required, write a paragraph explaining the breaking changes, c
 - NEVER add "Generated with Claude Code" or similar signatures to commit messages or PR body
 - NO emojis unless explicitly requested
 - Before generating PR content, ensure the `run-linters` skill has been executed to verify code quality
-- The skill is not done until Step 6 has run (or has been deliberately skipped because of a worktree). Do not stop after printing the Step 2 block.
+- Run the existing test suite locally before pushing (Step 4) — for Swift/iOS that means `swift test` or `xcodebuild test`, which run on this Mac; never push a behavior change without running its tests, and never claim tests pass without the runner's own pass marker
+- After pushing, watch CI **in the background** (Step 7) — run `gh pr checks --watch` with `run_in_background: true` so the session is not blocked, then triage when it reports; one command covers GitHub Actions and Xcode Cloud alike, and the PR is not done while a required check is red. The token that opened the PR can read its checks, so run the command and act on its output.
+- The skill is not done until Step 8 has run (or has been deliberately skipped because of a worktree). Do not stop after printing the Step 2 block.


### PR DESCRIPTION
## Summary

Refines the `create-pr` skill and the `work-issue` command so PR creation runs tests locally, watches CI to completion, and reads check results instead of inventing a permissions excuse. Also removes the opt-in pre-PR review step from `work-issue`, which added friction without value after a high-effort implementation.

**Key changes:**

- `create-pr`: add **Step 4 "Run Tests Locally"** as a gate before pushing, with per-stack runner detection (JS/TS, Ruby, Python, Go, .NET, and Swift/iOS via `swift test` / `xcodebuild test`) and a requirement to paste the runner's own pass marker; renumber subsequent steps.
- `create-pr`: add **Step 7 "Monitor CI in the Background"** (`gh pr checks --watch`, non-blocking) covering GitHub Actions and Xcode Cloud, with positively-framed guidance that reading a PR's checks always works with the token that opened it — surface verbatim errors rather than claiming a missing `Checks:read` permission.
- `create-pr`: extend `allowed-tools` to cover the test runners (`xcodebuild`, `swift`, `xcrun`, `npm`, `yarn`, `pnpm`, `bundle`, `pytest`, `go`, `dotnet`).
- `work-issue`: remove the opt-in "Pre-PR review" step (3 parallel review agents) and renumber the remaining steps and cross-references.
- `work-issue`: add Swift/iOS runner detection to the test-setup step and align the CI-check wording with the `create-pr` skill.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation/instruction-only changes to skill and command markdown; no executable logic to test.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified