### PR TITLE
Switch create-pr CI monitoring from gh pr checks to Actions runs REST API

### DIFF
--- a/commands/work-issue.md
+++ b/commands/work-issue.md
@@ -273,7 +273,7 @@ Steps 4–6 are gated by Issue Type (detected above) — the gating note on each
     - NO footers, NO co-authors, NO "Generated with Claude Code" signatures
 
     **Open the PR via the `create-pr` skill:**
-    The `create-pr` skill takes care of running the test suite locally before pushing, pushing the branch, opening the PR, **watching CI in the background (`gh pr checks --watch`, non-blocking)**, and switching the working tree back to the default branch when done. Do NOT run `git push` or `gh pr create` here — the skill does both. The task is not done until CI is green: if the background watch reports a failing GitHub Actions or Xcode Cloud check, fix it and push again before handing off. Read the checks with `gh pr checks` and act on its output — the token that just opened the PR can read that PR's checks.
+    The `create-pr` skill takes care of running the test suite locally before pushing, pushing the branch, opening the PR, **watching CI in the background (via the Actions runs REST API, non-blocking)**, and switching the working tree back to the default branch when done. Do NOT run `git push` or `gh pr create` here — the skill does both. The task is not done until CI is green: if the background watch reports a failing GitHub Actions or Xcode Cloud check, fix it and push again before handing off. Read CI status with the Actions runs REST API (`gh api "repos/<owner>/<repo>/actions/runs?head_sha=<SHA>"` → `/actions/runs/<id>/jobs`), not `gh pr checks` — this workflow's fine-grained PAT has no Checks permission and cannot read check runs, so `gh pr checks` always 403s here. See the `create-pr` skill's Step 7.
 
     When invoking the skill, override its commit-message / PR-title defaults with the issue-tagged form:
 

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -135,26 +135,33 @@ If a PR already exists for `$CURRENT_BRANCH` (e.g., the caller already opened it
 
 ## Step 7: Monitor CI in the Background
 
-A pushed PR is not done until its checks are green — but CI (especially Xcode Cloud) can take several minutes, so **watch it without blocking the session**. Launch the watch as a background task, then continue straight to Step 8. The background watch re-invokes you when CI settles, so a failure is still caught and triaged in this session — just not by sitting idle.
+A pushed PR is not done until its checks are green — but CI can take several minutes, so **watch it without blocking the session**. Launch the watch as a background task, then continue straight to Step 8. The background watch re-invokes you when CI settles, so a failure is still caught and triaged in this session — just not by sitting idle.
 
-Run this with the Bash tool's **`run_in_background: true`** (do not foreground it):
+**Read CI status with the Actions runs REST API — not `gh pr checks`.** This workflow authenticates with a **fine-grained PAT**, which has no "Checks" permission (the Checks API is GitHub-App-only), so `gh pr checks` always fails here with `Resource not accessible by personal access token` on `statusCheckRollup...contexts`. Do not use it. The REST `actions/runs` endpoint uses the `Actions` permission the PAT does have:
 
 ```bash
-gh pr checks "$CURRENT_BRANCH" --watch --fail-fast
+SHA=$(git rev-parse "$CURRENT_BRANCH")
+# Poll until the run completes, then list each job's conclusion.
+while :; do
+  read -r STATUS RUN_ID < <(gh api "repos/{owner}/{repo}/actions/runs?head_sha=$SHA&event=pull_request&per_page=1" --jq '.workflow_runs[0] | "\(.status) \(.id)"')
+  [ "$STATUS" = "completed" ] && break
+  sleep 30
+done
+gh api "repos/{owner}/{repo}/actions/runs/$RUN_ID/jobs" --jq '.jobs[] | {name, status, conclusion}'
 ```
 
-`gh pr checks` reports **every** check registered on the PR — GitHub Actions **and Xcode Cloud**, which posts its build/test result back to GitHub as a check run. So this one command covers both CIs. (`--fail-fast` returns as soon as one check fails; drop it to wait for the full set.) The command exits non-zero if any check fails, zero if all pass.
+Run the loop with the Bash tool's **`run_in_background: true`** (do not foreground it) so the session is not blocked; it re-invokes you when the run completes. Any job `conclusion` other than `success` / `skipped` / `neutral` is a failure.
 
-> **Reading the checks always works here — run `gh pr checks` and report what it returns.** The token that just pushed the branch and opened the PR has everything needed to read that PR's checks, so trust the command and let its output drive your next step. If it ever errors, surface the **verbatim** output and exit code so the real cause is visible. A 404/403 means the wrong working directory loaded the wrong per-repo token — `cd` into the PR's repo and retry.
+> **Xcode Cloud:** its result only surfaces as a *check run*, which the fine-grained PAT cannot read — so it does **not** appear in `actions/runs`. For Xcode Cloud pass/fail and logs, use the `appstore` skill.
 
-Do **not** wait on it before Step 8 — proceed immediately. When the background task completes:
+When the background watch completes:
 
-- **All checks green (exit 0):** report it; nothing more to do.
-- **A check fails (non-zero):** Step 8 has likely already returned you to the default branch, so re-checkout the PR branch first (`git checkout "$CURRENT_BRANCH"`), then pull the failing logs, fix the cause, and push again (re-run Steps 4–7). Do not leave the PR with a red required check.
-  - GitHub Actions: `gh run view --log-failed` (the failing run URL is also printed by `gh pr checks`).
+- **All jobs green:** report it; nothing more to do.
+- **A job failed:** Step 8 has likely already returned you to the default branch, so re-checkout the PR branch first (`git checkout "$CURRENT_BRANCH"`), then pull the failing logs, fix the cause, and push again (re-run Steps 4–7). Do not leave the PR with a red required check.
+  - GitHub Actions: `gh run view "$RUN_ID" --log-failed`.
   - **Xcode Cloud:** the check tells you only pass/fail. For the failing test names and logs, use the `appstore` skill — `asc-mcp` does not expose the `ci*` endpoints, so the failing `.xcresult` must be fetched via the App Store Connect API and read with `xcrun xcresulttool`.
 
-If the repo has no CI configured, `gh pr checks` exits immediately with no checks — note that and continue.
+If `actions/runs` returns no run for the SHA and the repo has no Actions workflows, there is no CI to wait on — note that and continue.
 
 ## Step 8: Return to Default Branch
 
@@ -239,5 +246,5 @@ If the section is required, write a paragraph explaining the breaking changes, c
 - NO emojis unless explicitly requested
 - Before generating PR content, ensure the `run-linters` skill has been executed to verify code quality
 - Run the existing test suite locally before pushing (Step 4) — for Swift/iOS that means `swift test` or `xcodebuild test`, which run on this Mac; never push a behavior change without running its tests, and never claim tests pass without the runner's own pass marker
-- After pushing, watch CI **in the background** (Step 7) — run `gh pr checks --watch` with `run_in_background: true` so the session is not blocked, then triage when it reports; one command covers GitHub Actions and Xcode Cloud alike, and the PR is not done while a required check is red. The token that opened the PR can read its checks, so run the command and act on its output.
+- After pushing, watch CI **in the background** (Step 7) — read status with the Actions runs REST API (`actions/runs?head_sha=…` → `/jobs`), not `gh pr checks` (the fine-grained PAT can't read check runs). Run the poll loop with `run_in_background: true` so the session is not blocked, then triage when it reports; the PR is not done while a required check is red. Xcode Cloud results don't appear in `actions/runs` — use the `appstore` skill for those.
 - The skill is not done until Step 8 has run (or has been deliberately skipped because of a worktree). Do not stop after printing the Step 2 block.


### PR DESCRIPTION
## Summary

This PR rewrites the CI-monitoring guidance in the `create-pr` skill (Step 7) to read check status through the GitHub Actions runs REST API instead of `gh pr checks`. This workflow authenticates with a fine-grained PAT, which has no "Checks" permission (the Checks API is GitHub-App-only), so `gh pr checks` always fails here with `Resource not accessible by personal access token`. The `actions/runs` endpoint uses the `Actions` permission the PAT does have, so it actually works. The `work-issue` command's reference to the old approach is updated to match.

**Key changes:**

- Replace the `gh pr checks --watch` poll in `create-pr` Step 7 with an `actions/runs?head_sha=…` → `/jobs` REST polling loop that runs in the background.
- Document that the fine-grained PAT cannot read check runs, and that Xcode Cloud results (which surface only as check runs) therefore won't appear in `actions/runs` — point to the `appstore` skill for those.
- Update the failure-triage notes to use `gh run view "$RUN_ID" --log-failed` and the "no CI" case to key off `actions/runs` returning no run.
- Update the Important Rules summary in `create-pr` and the `create-pr` reference in `commands/work-issue.md` to describe the REST API approach.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change to skill/command markdown; no executable code.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified