### PR TITLE
Add monday.com integration via official MCP server and skill

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -58,6 +58,10 @@
     "gcloud": {
       "command": "npx",
       "args": ["-y", "@google-cloud/gcloud-mcp"]
+    },
+    "monday": {
+      "command": "npx",
+      "args": ["-y", "@mondaydotcomorg/monday-api-mcp@latest"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This plugin provides development workflow automation for Claude Code.
 * Project documentation review (README, architecture, user guide)
 * Sprint work summaries grouped by repository
 * Translation asset management via Loco (localise.biz) API
+* monday.com board, item, and work-management operations
 * Firebase Crashlytics crash analysis via BigQuery
 * Figma design-to-code review for Android, iOS, and web
 * Vercel deployment management and documentation search
@@ -460,6 +461,7 @@ These skills are automatically available to Claude. The **Setup
 | `gcloud`                 | Manage Google Cloud infrastructure and services                 | `gcloud auth login && gcloud config set project <id>`. Optional: `CLOUDSDK_ACTIVE_CONFIG_NAME` for named configs                                                                                                                                   |
 | `heroku`                 | Manage Heroku apps, dynos, logs, and databases                  | `heroku login`                                                                                                                                                                                                                                     |
 | `loco`                   | Manage Loco translation assets (create, delete, scan)           | Env: `LOCO_API_KEY` *(or)* per-project `LOCO_API_KEY_<PROJECT>` (e.g. `LOCO_API_KEY_IOS`)                                                                                                                                                          |
+| `monday`                 | Manage monday.com boards, items, groups, columns, and updates   | Env: `MONDAY_TOKEN` (personal access token from avatar → Developers → My access tokens). MCP-only — no CLI fallback                                                                                                                                |
 | `newrelic`               | Query New Relic observability data, alerts, and logs            | newrelic remote MCP *(or)* `newrelic profile add --name default --apiKey NRAK-... --accountId ...`                                                                                                                                                 |
 | `paypal`                 | Manage PayPal invoices, payments, and disputes                  | paypal remote MCP **(required — no CLI fallback)**                                                                                                                                                                                                 |
 | `playstore`              | Fetch, analyze, and respond to Google Play reviews              | Env: `GOOGLE_APPLICATION_CREDENTIALS` (path to service-account JSON; needs Google Play Developer API + Play Console access). Requires `uv`/`uvx` on PATH.                                                                                          |

--- a/skills/monday/SKILL.md
+++ b/skills/monday/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: monday
+description: Manage monday.com boards, items, and work management data. Use when the user wants to look up or create items, search a board, update item status or column values, add an update/comment, move items between groups, create boards, groups, or columns, inspect a board's schema, look up users or teams, or create and read WorkForms in monday.com.
+allowed-tools: mcp__monday__*, Bash(jq:*), Bash(echo:*)
+---
+
+# monday.com
+
+Manage monday.com boards, items, groups, columns, and updates via the official
+monday MCP server.
+
+## Authentication
+
+This skill uses the **monday MCP server only** — there is no monday CLI fallback.
+The server (`mcp__monday__*`) reads a **personal access token** from the
+`MONDAY_TOKEN` environment variable.
+
+To get a token: in monday.com, click your **avatar → Developers → My access
+tokens**, and copy your personal token. Export it before launching Claude Code:
+
+```bash
+export MONDAY_TOKEN="your_monday_api_token"
+```
+
+All tool calls execute as that user and are subject to that user's monday.com
+permissions. If `mcp__monday__*` tools are not available (tool not found errors),
+the token is missing or the MCP server failed to start — inform the user and stop.
+
+## MCP Tools
+
+| Operation | Tool |
+| --- | --- |
+| **Search items by name** | `mcp__monday__get_board_items_by_name` |
+| **Create item** | `mcp__monday__create_item` |
+| **Update column values** | `mcp__monday__change_item_column_values` |
+| **Move item to group** | `mcp__monday__move_item_to_group` |
+| **Delete item** | `mcp__monday__delete_item` |
+| **Add update / comment** | `mcp__monday__create_update` |
+| **Get board schema** (columns + groups) | `mcp__monday__get_board_schema` |
+| **Create board** | `mcp__monday__create_board` |
+| **Create group** | `mcp__monday__create_group` |
+| **Create column** | `mcp__monday__create_column` |
+| **Delete column** | `mcp__monday__delete_column` |
+| **List users and teams** | `mcp__monday__list_users_and_teams` |
+| **Create form** | `mcp__monday__create_form` |
+| **Get form** | `mcp__monday__get_form` |
+
+**Dynamic API tools** (`mcp__monday__all_monday_api`, `get_graphql_schema`,
+`get_type_details`) expose the full GraphQL API but are **disabled by default**.
+They require launching the server with `--enable-dynamic-api-tools true` and are
+not compatible with read-only mode.
+
+## Usage
+
+1. **Understand the request** — which board, item, or field? If the board or
+   column IDs are unknown, call `get_board_schema` (or
+   `get_board_items_by_name`) first to discover them.
+2. **Resolve before mutating** — column values must match the board's column
+   types and IDs; fetch the schema before `create_item` or
+   `change_item_column_values` rather than guessing.
+3. **Execute** the appropriate MCP tool.
+4. **Present results** clearly — show item names with their IDs, board name, and
+   the relevant column values.
+
+## Important Rules
+
+- **Never create, modify, move, or delete boards, items, columns, or updates
+  without explicit user confirmation** — these write to live workspace data.
+- **`delete_item` and `delete_column` are permanent** — always confirm the exact
+  target (by name *and* ID) before deleting.
+- **Always show IDs** alongside names when presenting results, so the user can
+  act on the right object.
+- **Respect permissions** — calls run as the token's user; if a call fails with a
+  permission error, report it rather than retrying with a different approach.


### PR DESCRIPTION
## Summary

Adds a monday.com integration to the plugin using monday.com's official, MIT-licensed MCP server (`@mondaydotcomorg/monday-api-mcp`, maintained by the monday.com AI team). The server runs locally via `npx` and authenticates with a personal access token read from the `MONDAY_TOKEN` environment variable — consistent with how every other account-bound server in this plugin reads credentials from the inherited shell environment rather than storing them in `.mcp.json`.

**Key changes:**

- Register the `monday` server in `.mcp.json` (`npx -y @mondaydotcomorg/monday-api-mcp@latest`).
- Add `skills/monday/SKILL.md` — a skill mirroring the `stripe`/`vercel` template: authentication instructions (`MONDAY_TOKEN`), an MCP tool reference for board/item/group/column/update/form operations, usage steps, and write/delete confirmation guardrails. Notes it is MCP-only with no CLI fallback.
- Update `README.md`: add a Features bullet and a `monday` row in the Skills table (alphabetical) documenting the `MONDAY_TOKEN` setup.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: This adds an MCP server config and a documentation-only skill; the plugin has no automated test harness for skills/MCP wiring.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified