### PR TITLE
Sync deep code review to default branch and relax confidence thresholds

### DIFF
--- a/commands/code-review-deep.md
+++ b/commands/code-review-deep.md
@@ -24,6 +24,18 @@ cd /path/to/repo-under-review        # or, when already inside it: cd "$(git rev
 
 Run the `cd` as a **separate** call — never chain it as `cd … && gh …`. direnv reloads `.envrc` on the next prompt, so the *following* calls get the right token; a command on the same line as the `cd` still runs with the old environment.
 
+## Sync to the default branch and pull latest
+
+Review the up-to-date default branch, not whatever was last checked out. Once the repo is the working directory (and after direnv has reloaded), switch to the default branch if not already on it and fast-forward to the remote:
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')
+git switch "$DEFAULT_BRANCH"
+git pull --ff-only
+```
+
+If the working tree is dirty or the pull can't fast-forward, **stop and tell the user** rather than discarding or merging their changes — they may want the review to run against the current state. Skip the switch when the user explicitly scoped the review to a feature branch or specific path.
+
 ## MCP Tools with Fallbacks
 
 Prefer MCP tools (`mcp__github__*`, `mcp__context7__*`) when available; fall back to `gh` CLI / `WebSearch` on errors. Don't let MCP failures block the review.
@@ -100,7 +112,7 @@ Workflow({
 | Scan | 3 parallel `Explore` | Tech stack (+ applicability booleans), config inventory, structure |
 | Analyze | 7–11 parallel `general-purpose` | Core agents always run; backend / infra-compliance / i18n-ml / prompt-artifacts run only when Phase 1 flags them |
 | Verify | N parallel (≤10 findings each) | Adversarial validation that tries to **disprove** each finding, with a 0–100 confidence score |
-| Filter | (in-script) | Per-severity confidence thresholds: Critical ≥50, High ≥70, Medium ≥75, Low ≥85, Info ≥90 |
+| Filter | (in-script) | Per-severity confidence thresholds: Critical ≥40, High ≥60, Medium ≥65, Low ≥75, Info ≥80 |
 
 The workflow runs in the background and notifies you on completion. It **returns a structured object**:
 

--- a/commands/code-review-deep.workflow.js
+++ b/commands/code-review-deep.workflow.js
@@ -29,7 +29,7 @@ const scope = input.scope || 'the whole repository'
 // --- Per-severity confidence thresholds (Phase 3.5) ------------------------
 // Critical/High survive at lower confidence (cost of a miss is high); Medium/
 // Low/Info need higher confidence so stochastic re-runs stay deterministic.
-const SEV_THRESHOLDS = { critical: 50, high: 70, medium: 75, low: 85, info: 90 }
+const SEV_THRESHOLDS = { critical: 40, high: 60, medium: 65, low: 75, info: 80 }
 
 function normSev(s) {
   const t = String(s || '').toLowerCase()


### PR DESCRIPTION
## Summary

Two refinements to the deep code review command so it audits the right code and surfaces more findings.

First, the review now explicitly syncs the target repo to its up-to-date default branch before the analysis workflow runs, rather than auditing whatever happened to be checked out. Second, the per-severity confidence thresholds in the filter phase are relaxed by 10 points across the board, letting more findings survive into the final report while still filtering out low-confidence noise.

**Key changes:**

- Add a "Sync to the default branch and pull latest" step to `code-review-deep.md`: resolve the default branch (via `gh repo view`, with a `git symbolic-ref` fallback), `git switch` to it, and `git pull --ff-only` — stopping to ask the user on a dirty tree or non-fast-forward instead of clobbering changes, and skipping when the review is scoped to a feature branch or path.
- Lower `SEV_THRESHOLDS` in `code-review-deep.workflow.js`: Critical 50→40, High 70→60, Medium 75→65, Low 85→75, Info 90→80.
- Update the Filter-phase reference table in `code-review-deep.md` to match the new thresholds.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Command/skill prompt + workflow-script changes; repo has no test harness for these
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified