### PR TITLE
Add parallel workflow mode to work-issue and verify-resolved-issues

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -40,10 +40,12 @@ jobs:
           exit 0
         fi
 
-        # Collect @handles only from the catch-all (*) line — the repo-wide code owners
+        # Collect @handles only from the catch-all (*) line — the repo-wide code owners.
+        # `|| true` keeps the pipeline from aborting under `set -euo pipefail` when there
+        # is no `*` line (grep exits 1); empty handles then degrade to is_owner=false below.
         handles=$(grep -E '^\*\s' "$CODEOWNERS" \
           | grep -oE '@[A-Za-z0-9_.\-]+(/[A-Za-z0-9_.\-]+)?' \
-          | sort -u)
+          | sort -u || true)
 
         is_owner=false
         for h in $handles; do
@@ -71,7 +73,6 @@ jobs:
       env:
         GH_TOKEN: "${{secrets.GH_PAT}}"
         AUTHOR: "${{github.event.pull_request.user.login}}"
-        ORG: "${{github.repository_owner}}"
     - name: Approve PR
       shell: bash
       if: steps.check.outputs.is_owner == 'true'

--- a/commands/work-issue.md
+++ b/commands/work-issue.md
@@ -1,7 +1,7 @@
 ---
-description: Implement a GitHub issue or Jira ticket end-to-end (explore, design, implement, PR)
-argument-hint: <issue-number-or-jira-key>
-allowed-tools: Bash(git:*), Bash(gh:*), Bash(jira:*), Bash(awk:*), Bash(cat:*), Bash(echo:*), Bash(grep:*), Bash(jq:*), Bash(sed:*), Bash(tr:*), Read, Edit, Write, Glob, Grep, TodoWrite, Agent, mcp__github__*, mcp__atlassian__*, mcp__figma__*
+description: Implement one or more GitHub issues or Jira tickets end-to-end (explore, design, implement, PR). Multiple issues run in parallel.
+argument-hint: <issue-number-or-jira-key> [more-issues...]
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(jira:*), Bash(awk:*), Bash(cat:*), Bash(echo:*), Bash(grep:*), Bash(jq:*), Bash(sed:*), Bash(tr:*), Read, Edit, Write, Glob, Grep, TodoWrite, Agent, Workflow, AskUserQuestion, mcp__github__*, mcp__atlassian__*, mcp__figma__*
 ---
 
 Work on issue: $ARGUMENTS
@@ -59,6 +59,73 @@ When the issue description or comments contain Figma URLs (`figma.com/design/...
 | Get screenshot | `mcp__figma__get_screenshot` |
 | Search design system | `mcp__figma__search_design_system` |
 
+## Single issue vs. multiple issues (mode select)
+
+Parse `$ARGUMENTS` into a list of issue refs (split on whitespace and/or commas; e.g. `123 124 DEV-5` or `123, 124`). Count them:
+
+- **One ref → sequential mode (default).** Run the full interactive workflow below (Steps 0–12) exactly as written. The clarifying-questions gate (Step 5) and architecture-choice gate (Step 6) need a human in the loop, so a single issue keeps the rich back-and-forth.
+- **Two or more refs → parallel mode.** Implement them concurrently via the workflow described in the next section, then open PR(s). Use parallel mode when the user passes a batch of issues — it is best for Bugs and well-specified Tasks. If any ref is a **Feature likely to need design discussion**, tell the user it is better done on its own in sequential mode, and offer to either implement it autonomously (the agent records its assumptions for review) or split it out.
+
+---
+
+## Parallel mode (multiple issues)
+
+Each issue is implemented by its own agent in its own **git worktree**, so parallel file edits never collide. The fan-out runs as a deterministic workflow (`work-issue.workflow.js`); your job in the command is the preflight, launching the workflow, and the human-in-the-loop PR decision at the end.
+
+**Why a workflow:** the per-issue explore → implement → test → commit loop is independent across issues, so it parallelises cleanly. What does NOT parallelise — the single "separate vs. combined PR" decision and PR creation itself — stays here in the command.
+
+### P1 — Preflight
+
+`cd` into the target repo in its own Bash call (so direnv loads the right token — see the direnv note above), then gather the base context once:
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+REPO_ROOT=$(git rev-parse --show-toplevel)
+git fetch --all --quiet
+```
+
+Detect the tracker once (`gh repo view --json hasIssuesEnabled --jq '.hasIssuesEnabled'`) and reuse it for every ref — a batch is assumed to target one repo/tracker. Refuse to start if the working tree has uncommitted changes (the worktrees branch from `origin/$DEFAULT_BRANCH`, but a dirty main checkout still signals risk) — ask the user to stash/commit first.
+
+### P2 — Launch the workflow
+
+```text
+Workflow({
+  scriptPath: "${CLAUDE_PLUGIN_ROOT}/commands/work-issue.workflow.js",
+  args: {
+    defaultBranch: "<DEFAULT_BRANCH>",
+    repoRoot: "<REPO_ROOT>",
+    issues: [ { ref: "123", tracker: "github" }, { ref: "124", tracker: "github" } ]
+  }
+})
+```
+
+Each agent fetches its issue, creates branch `issue-<n>` (GitHub) or `<KEY>` uppercase (Jira) from `origin/$DEFAULT_BRANCH`, implements the change, **writes and runs tests (hard gate — same rule as Step 8)**, and commits with the correct issue-tagged, signature-free message. Agents are autonomous (no mid-run questions) and record any judgement calls in `assumptions[]`. They do **not** push or open PRs. The workflow returns:
+
+```text
+{
+  defaultBranch, repoRoot,
+  results: [ { ref, tracker, branch, issue_type, title, success, summary,
+               files_changed, test_status, assumptions, pr_title, closing_keyword, block_reason } ]
+}
+```
+
+The implementation rules (branch naming, issue-type → commit prefix, the test hard-gate, no-signature commits) live in `${CLAUDE_PLUGIN_ROOT}/commands/work-issue.workflow.js` — edit that file to tune the parallel path.
+
+### P3 — Review results
+
+Present a compact per-issue summary from `results`: outcome, branch, `test_status`, `files_changed`, and any `assumptions`. For any `success:false`, show `block_reason` and **exclude it from PR creation** — offer to retry it in sequential mode. Let the user eyeball the diffs (`git diff origin/$DEFAULT_BRANCH...<branch>`) before opening anything.
+
+### P4 — Ask: separate PRs or one combined PR?
+
+Once the user is happy, use `AskUserQuestion` to decide how to ship the successful branches:
+
+- **Separate PRs (one per issue)** — for each successful result, open a PR from its branch via the `create-pr` skill, using its `pr_title` and adding its `closing_keyword` to the PR **body** (GitHub). This is the default when the issues are unrelated.
+- **Single combined PR** — create one integration branch from `origin/$DEFAULT_BRANCH`, merge each successful issue branch into it (`git merge --no-ff <branch>` per issue; resolve any conflicts, re-run tests), then open one PR via `create-pr`. Put **every** issue's closing keyword on its own line in the body (`Closes #123`, `Fixes #124`, …) so all of them auto-close on merge. Use this when the issues are tightly related or the user wants a single review.
+
+In both cases the `create-pr` skill handles running tests locally, pushing, opening the PR, and watching CI (via the Actions runs REST API) — do not `git push` / `gh pr create` yourself. After PRs are open, run Steps 10–11 (update issue, post the tester QA checklist) per issue, and for Jira transition each to **Code Review**. Then clean up worktrees (`git worktree remove .worktrees/<branch>` or the workflow's temporary worktrees) once the user confirms, preserving the branches until the PRs merge.
+
+---
+
 ## Detect Issue Tracker
 
 ```bash
@@ -95,7 +162,9 @@ After fetching the issue details, determine the issue type:
 
 For Jira issues, always use `$ARGUMENTS: <description>` (the Jira key is the prefix).
 
-## Workflow
+## Workflow (sequential mode — single issue)
+
+This is the full interactive flow for **one** issue. For two or more issues, use Parallel mode above instead; it reuses these same rules (issue-type detection, the test hard-gate, commit/PR conventions) but runs them per-issue in isolated worktrees.
 
 Steps 4–6 are gated by Issue Type (detected above) — the gating note on each step shows when to run it. **Step 8 (write and run unit tests) is a hard gate for any change that alters behavior**, regardless of issue type; the PR cannot be opened until it is satisfied or an explicit no-test exception applies.
 

--- a/commands/work-issue.workflow.js
+++ b/commands/work-issue.workflow.js
@@ -1,0 +1,159 @@
+export const meta = {
+  name: 'work-issue-parallel',
+  description: 'Implement several issues at once: one worktree-isolated agent per issue (explore, implement, write+run tests, commit on a branch), returning a per-issue result the command turns into PR(s)',
+  phases: [
+    { title: 'Implement', detail: 'one worktree-isolated agent per issue: fetch, explore, implement, test, commit' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Parallel path for the work-issue command. Used ONLY when the user passes
+// more than one issue. A single issue still runs the normal interactive flow
+// in work-issue.md (clarifying-questions gate, architecture choice, per-step
+// approval) — those gates need a human and don't fit a background workflow.
+//
+// Each issue is implemented by its OWN agent in its OWN git worktree
+// (isolation: 'worktree') so parallel file edits never collide. Each agent
+// commits its work on a dedicated branch; because worktrees share the repo's
+// object store and refs, those branches persist after the worktree is removed,
+// so the command can open PR(s) from them afterwards.
+//
+// This workflow deliberately STOPS at "committed on a branch, tests green". It
+// does NOT open PRs — the command asks the user "separate PRs or one combined
+// PR?" once, after this returns, and drives create-pr accordingly.
+//
+// Invoked by commands/work-issue.md via:
+//   Workflow({ scriptPath: "${CLAUDE_PLUGIN_ROOT}/commands/work-issue.workflow.js",
+//              args: { issues: [{ ref, tracker }], defaultBranch, repoRoot } })
+// ---------------------------------------------------------------------------
+
+const input = args || {}
+const issues = Array.isArray(input.issues) ? input.issues : []
+const defaultBranch = input.defaultBranch || 'main'
+const repoRoot = input.repoRoot || '.'
+
+function branchName(issue) {
+  const ref = String(issue.ref)
+  return issue.tracker === 'jira' ? ref.toUpperCase() : 'issue-' + ref
+}
+
+function buildImplementPrompt(issue) {
+  const isJira = issue.tracker === 'jira'
+  const ref = String(issue.ref)
+  const branch = branchName(issue)
+  return [
+    'You are implementing ONE issue end-to-end inside an ISOLATED git worktree, in parallel with other agents',
+    'working on other issues. Stay entirely within your worktree — never touch another issue\'s files or branch.',
+    '',
+    '## Issue',
+    'Tracker: ' + (isJira ? 'Jira' : 'GitHub') + '  ·  Ref: ' + ref,
+    'Base branch: origin/' + defaultBranch,
+    'Your branch: ' + branch + (isJira ? '  (Jira keys are UPPERCASE)' : ''),
+    '',
+    '## Steps',
+    '1. Fetch the issue details:',
+    isJira
+      ? '   - `mcp__atlassian__getJiraIssue` (preferred) or `jira issue view ' + ref + ' --comments 16`.'
+      : '   - `mcp__github__get_issue` (preferred) or `gh issue view ' + ref + ' --comments`.',
+    '   Read the title, description, acceptance criteria, and comments. If Figma URLs appear, pull design context',
+    '   via `mcp__figma__*` when available (skip silently if not).',
+    '',
+    '2. Create your branch from the LATEST base, inside your worktree:',
+    '   ```bash',
+    '   git fetch --all --quiet',
+    '   git checkout -b ' + branch + ' origin/' + defaultBranch + ' 2>/dev/null || git checkout ' + branch,
+    '   git submodule update --init --recursive',
+    '   ```',
+    '',
+    '3. Determine the issue TYPE and act accordingly:',
+    '   - Bug → implement the fix directly (you already know the failure point). Write a regression test that',
+    '     FAILS before the fix and PASSES after; confirm both.',
+    '   - Task → implement directly. If non-trivial, briefly explore the relevant code first.',
+    '   - Feature → explore similar features and the architecture before implementing, then build the smallest',
+    '     correct change that satisfies the acceptance criteria.',
+    '   You are autonomous here (no human to ask mid-run). Where the issue is ambiguous, choose the most',
+    '   conventional interpretation, implement it, and RECORD the assumption in your result\'s `assumptions[]`',
+    '   so the user can review it at PR time. Do not invent scope beyond the issue.',
+    '',
+    '4. Tests are a HARD GATE. Any behaviour-altering change must be covered by tests that pass:',
+    '   - Find the project\'s test runner from the manifest/config; match the nearest existing tests\' style.',
+    '   - Cover the success path AND the negative/failure paths AND the regression surface of anything shared',
+    '     you changed.',
+    '   - Run the narrow suite for the touched area. Capture the runner\'s OWN pass marker (e.g. `0 failures`,',
+    '     `N passed`, `ok`, `** TEST SUCCEEDED **`) into `test_status` — never paraphrase "tests pass".',
+    '   - No-test exception is narrow and must be stated: pure copy/i18n, static assets, formatting-only,',
+    '     config/docs, generated files. "Hard to test" is NOT an exception — if you cannot test it, set',
+    '     `success:false` and explain in `block_reason` rather than shipping untested code.',
+    '',
+    '5. Commit on your branch — single-line message, NO footers, NO co-authors, NO "Generated with Claude Code":',
+    '   ```bash',
+    '   git add -A',
+    isJira
+      ? '   git commit -m "' + ref + ': <brief description>"'
+      : '   git commit -m "<PREFIX> #' + ref + ': <brief description>"   # PREFIX: Bug→Fix, Feature→Feat, Task→(none)',
+    '   ```',
+    '   Do NOT push and do NOT open a PR — the command handles PRs after all agents finish.',
+    '',
+    '## Return',
+    'Report your result. `pr_title` and `closing_keyword` are what the command will use when it opens the PR:',
+    isJira
+      ? '- pr_title: "' + ref + ' <summary>"   ·   closing_keyword: "" (Jira closes via transition, not keywords)'
+      : '- pr_title: "<PREFIX> #' + ref + ': <summary>"   ·   closing_keyword: "' + 'Fixes #' + ref + '" for a Bug, else "Closes #' + ref + '"',
+    'Set `success:false` (with `block_reason`) if you could not implement or could not make tests pass — the',
+    'command will surface it and skip that issue\'s PR rather than open a broken one.',
+  ].join('\n')
+}
+
+const RESULT_SCHEMA = {
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    ref: { type: ['string', 'integer'] },
+    tracker: { type: 'string' },
+    branch: { type: 'string' },
+    issue_type: { type: 'string' },        // Bug | Feature | Task
+    title: { type: 'string' },
+    success: { type: 'boolean' },
+    summary: { type: 'string' },           // what was implemented
+    files_changed: { type: 'array', items: { type: 'string' } },
+    test_status: { type: 'string' },       // pasted runner marker, or stated no-test exception
+    assumptions: { type: 'array', items: { type: 'string' } },
+    pr_title: { type: 'string' },
+    closing_keyword: { type: 'string' },
+    block_reason: { type: 'string' },      // when success:false
+  },
+  required: ['ref', 'branch', 'success', 'summary'],
+}
+
+// ===========================================================================
+// PHASE: IMPLEMENT — one worktree-isolated agent per issue, in parallel.
+// ===========================================================================
+phase('Implement')
+
+if (!issues.length) {
+  log('No issues passed in — nothing to implement.')
+  return { defaultBranch, repoRoot, results: [] }
+}
+
+log('Implementing ' + issues.length + ' issues in parallel, each in its own git worktree: ' + issues.map(i => i.ref).join(', '))
+
+const results = await pipeline(
+  issues,
+  (issue) => agent(buildImplementPrompt(issue), {
+    label: 'impl:' + issue.ref,
+    phase: 'Implement',
+    schema: RESULT_SCHEMA,
+    agentType: 'general-purpose',
+    isolation: 'worktree',
+  }).then(r => {
+    if (!r) return { ref: issue.ref, tracker: issue.tracker, branch: branchName(issue), success: false, summary: '', block_reason: 'agent did not return a result (skipped or errored)' }
+    return { ...r, ref: r.ref ?? issue.ref, tracker: r.tracker || issue.tracker, branch: r.branch || branchName(issue) }
+  })
+)
+
+const clean = results.filter(Boolean)
+const ok = clean.filter(r => r.success)
+const failed = clean.filter(r => !r.success)
+log('Implemented ' + ok.length + '/' + issues.length + ' successfully' + (failed.length ? ' · ' + failed.length + ' need attention: ' + failed.map(f => f.ref).join(', ') : ''))
+
+return { defaultBranch, repoRoot, results: clean }

--- a/skills/verify-resolved-issues/SKILL.md
+++ b/skills/verify-resolved-issues/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: verify-resolved-issues
 description: Audit issues in a "resolved" / "fixed" / "done" state that have not been closed yet, verify the fix actually exists in the current codebase, then either close them with a detailed summary or kick them back to the original resolver with an explanation. Use when the user wants to verify resolved issues, audit resolved tickets, audit closed issues, check fixed bugs, close stale resolved issues, clean up the resolved column, sweep resolved issues, sweep done tickets, verify fixes, confirm resolutions, validate that fixed issues are really fixed, or review the resolved-but-not-closed backlog. Works against GitHub Issues if enabled on the repo, otherwise against Jira. Handles Jira projects with separate "Resolved" → "Closed" workflow as well as projects that use a single terminal state.
-allowed-tools: Bash(gh:*), Bash(jira:*), Bash(git:*), Bash(curl:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(printf:*), Bash(rm:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Grep, Glob, Write, Edit, mcp__github__list_issues, mcp__github__get_issue, mcp__github__search_issues, mcp__github__add_issue_comment, mcp__github__update_issue, mcp__github__get_pull_request, mcp__github__get_pull_request_files, mcp__github__list_commits, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__addCommentToJiraIssue, mcp__atlassian__transitionJiraIssue, mcp__atlassian__getTransitionsForJiraIssue
+allowed-tools: Bash(gh:*), Bash(jira:*), Bash(git:*), Bash(curl:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(printf:*), Bash(rm:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Grep, Glob, Write, Edit, Workflow, Agent, mcp__github__list_issues, mcp__github__get_issue, mcp__github__search_issues, mcp__github__add_issue_comment, mcp__github__update_issue, mcp__github__get_pull_request, mcp__github__get_pull_request_files, mcp__github__list_commits, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__addCommentToJiraIssue, mcp__atlassian__transitionJiraIssue, mcp__atlassian__getTransitionsForJiraIssue
 ---
 
 # Verify Resolved Issues
@@ -84,6 +84,60 @@ If both are passed, that's a contradiction — ask the user which they meant.
 
 ---
 
+## Parallel verification via workflow
+
+The expensive part of this skill — reading each issue's claims, reading its linked PR, cross-checking the current working tree, running narrow tests, and drafting the audit comment — is **independent per issue**, so it runs as a deterministic fan-out workflow (`verify-resolved-issues.workflow.js`): one agent per candidate, all in parallel. This is the same split as `code-review-deep` — the heavy, repeatable judgement lives in the workflow; the parts that need credentials, scope decisions, and a human-in-the-loop confirmation stay here in the skill.
+
+**Division of labour:**
+
+- **The skill (this file) does:** tracker detection (Step 1), candidate discovery (Step 2-G / 2-J + 3-J), resolver identification (Step 3-G / 4-J), and finding the linked merged PRs (Step 5-J). Then it **confirms once** before any write (`--apply`) and performs the actual writes (Step 5-G / 7-J).
+- **The workflow does:** the per-issue verification (Step 4-G / 6-J) and comment drafting, returning a structured verdict per issue. The verification checklist, the three-way outcome rules, the `SKIP_NEEDS_MANUAL` guidance, the comment templates, and the language rule all live in `${CLAUDE_PLUGIN_ROOT}/skills/verify-resolved-issues/verify-resolved-issues.workflow.js`. To tune *how a fix is judged or how a comment reads*, edit that file — not the steps below.
+
+**Before launching**, `cd` into the target repo (its own Bash call) so the workflow's agents inherit the right working directory and direnv token — their `gh`/`git`/test-runner calls depend on it. Then invoke:
+
+```text
+Workflow({
+  scriptPath: "${CLAUDE_PLUGIN_ROOT}/skills/verify-resolved-issues/verify-resolved-issues.workflow.js",
+  args: {
+    tracker: "github" | "jira",
+    scope: "<owner/repo, or project=<KEY>, sprint=<NAME|all>>",
+    ownerRepo: "<owner/repo>",
+    candidates: [
+      {
+        id: "<#NUM or KEY>",
+        title: "<issue title>",
+        url: "<issue url>",
+        body: "<issue description + acceptance criteria, as text>",
+        resolvedDate: "<ISO date the issue entered the resolved state>",
+        resolver: { login: "<gh login>", accountId: "<jira accountId>", displayName: "<name>" },
+        mergedPRs: [ { repo: "owner/repo", number: 123, url: "...", mergeCommit: "<sha>", mergedAt: "<iso>", author: "<login>", mergedBy: "<login>", files: ["path/a", "path/b"] } ],
+        finalClosedStatus: "<Jira final-closed status name, Jira only>",
+        initialStatus: "<Jira workflow start status name, Jira only>"
+      }
+    ]
+  }
+})
+```
+
+Pass **every** discovered candidate in one call — the workflow parallelises across them. It runs in the background and notifies you on completion, returning:
+
+```text
+{
+  tracker, scope,
+  counts:  { total, verified, not_verified, skip_manual, skip_insufficient, errored },
+  results: [ { id, title, url, outcome, one_line, comment_markdown, comment_language,
+               planned_action, resolver, files_reviewed, tests_run, evidence, mergedPRs } ]
+}
+```
+
+`outcome` is one of `VERIFIED` | `NOT_VERIFIED` | `SKIP_NEEDS_MANUAL` | `SKIP_INSUFFICIENT`. `comment_markdown` is the fully-filled, correctly-languaged comment to post verbatim (empty for the two `SKIP_*` outcomes — those are report-only and you must do nothing to the ticket).
+
+**Render the dry-run report** (the "Output (dry-run)" section) from `results` + `counts`. **On `--apply`**, after the single confirmation gate, perform the writes per `outcome` using the steps below: post `comment_markdown` first, then close/transition, then reassign on kick-backs. Do not re-verify — trust the workflow's verdict.
+
+The per-flow steps below remain the source of truth for **discovery and the writes**; treat their "verify in current codebase" steps (4-G / 6-J) as **delegated to the workflow** rather than executed inline.
+
+---
+
 ## GitHub Flow
 
 ### Step 2-G: Find candidate issues
@@ -118,6 +172,8 @@ For each candidate:
 4. Pull the diff: `gh pr diff <PR_NUM> --repo <owner>/<repo>` for review.
 
 ### Step 4-G: Verify in current codebase
+
+> **Delegated to the workflow.** Don't run this per-issue loop inline — pass all candidates discovered in Steps 2-G / 3-G to `verify-resolved-issues.workflow.js` (see "Parallel verification via workflow" above) and use its returned verdicts. The checklist below documents what each workflow agent does, and stays the source of truth for that logic.
 
 For each candidate, decide whether the merged PR's intent matches what the issue described AND whether the changes are still present on the default branch.
 
@@ -260,6 +316,8 @@ Filter to merged PRs. Repeat for `dataType=branch` and `dataType=repository` if 
 If dev-info is empty, fall back to a GitHub search for the issue key in PR titles/bodies/branches: `gh search prs --owner <org> "<KEY>" --merged --json repository,number,title,author,url`.
 
 ### Step 6-J: Verify in current codebase
+
+> **Delegated to the workflow.** Like Step 4-G, pass all candidates (with their resolver and linked-PR data from Steps 4-J / 5-J) to `verify-resolved-issues.workflow.js` and act on its verdicts. The procedure below is what each workflow agent runs.
 
 Same procedure as **Step 4-G**, including the three-way outcome: **VERIFIED**, **NOT_VERIFIED**, or **SKIP_NEEDS_MANUAL**. Read the issue description and acceptance criteria, read the touched files in the current working tree, confirm the described behavior is present, run tests/linters narrowly if useful. If the ticket's correctness cannot be determined from code alone (visual/UX bugs, third-party integrations, device-specific behavior — see Step 4-G), mark **SKIP_NEEDS_MANUAL** and **do nothing on the ticket** — no comment, no transition, no reassignment. Skipped tickets only show up in the report.
 

--- a/skills/verify-resolved-issues/verify-resolved-issues.workflow.js
+++ b/skills/verify-resolved-issues/verify-resolved-issues.workflow.js
@@ -1,0 +1,257 @@
+export const meta = {
+  name: 'verify-resolved-issues',
+  description: 'Verify each resolved-but-not-closed issue in parallel: read the issue + linked PR + current working tree, decide VERIFIED / NOT_VERIFIED / SKIP, and draft the audit comment',
+  phases: [
+    { title: 'Verify', detail: 'one agent per candidate issue: cross-check the fix against the working tree, decide the outcome, draft the comment in the issue language' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Canonical source of truth for the PER-ISSUE VERIFICATION behaviour of the
+// verify-resolved-issues skill: the verification checklist (Steps 4-G / 6-J),
+// the three-way outcome rules, the SKIP_NEEDS_MANUAL guidance, the comment
+// templates, and the language rule all live here. Edit THIS FILE to tune how a
+// single candidate is judged and what the drafted comment looks like.
+//
+// What stays in SKILL.md (NOT here, because it needs judgement, credentials,
+// and a human-in-the-loop confirmation a background workflow can't do):
+//   - tracker detection (GitHub vs Jira) and scope resolution
+//   - candidate discovery (the gh search / JQL queries, Step 2-G / 2-J/3-J)
+//   - resolver identification from PR author / Jira changelog
+//   - the single --apply confirmation gate
+//   - the actual writes (comment, close/transition, reassign)
+//
+// The skill gathers candidates, calls this workflow to verify them all in
+// parallel, then renders the dry-run report (and, on --apply, performs the
+// writes) from the structured array this workflow returns.
+//
+// Invoked by skills/verify-resolved-issues/SKILL.md via:
+//   Workflow({ scriptPath: "${CLAUDE_PLUGIN_ROOT}/skills/verify-resolved-issues/verify-resolved-issues.workflow.js",
+//              args: { tracker: "github"|"jira", scope: "...", candidates: [ ... ] } })
+//
+// Workflow agents inherit the working directory, so their `gh` / `git` / test
+// runner calls authenticate with whatever token the current directory's
+// .envrc provides — the skill must cd into the target repo BEFORE launching.
+// ---------------------------------------------------------------------------
+
+const input = args || {}
+const tracker = input.tracker === 'jira' ? 'jira' : 'github'
+const scope = input.scope || (tracker === 'jira' ? 'the active sprint' : 'this repository')
+const candidates = Array.isArray(input.candidates) ? input.candidates : []
+
+// --- Shared verification rules injected into every agent prompt ------------
+const VERIFY_RULES = [
+  '## How to verify (do every step — a skipped step means you cannot CONFIRM)',
+  '1. Read the issue body and acceptance criteria. Extract concrete, checkable claims:',
+  '   "Button X does Y", "Endpoint /foo returns 404 when ...", named files, functions, error messages.',
+  '2. Read the linked merged PR(s): the diff and the list of touched files. Note what the fix intended to do.',
+  '3. Read the touched files IN THE CURRENT WORKING TREE — not just the PR diff. A later commit may have',
+  '   reverted, refactored, or partially undone the change. The issue is fixed only if the behaviour is in the',
+  '   code NOW, on the current branch.',
+  '4. Cross-check the issue\'s claims against the current code:',
+  '   - If the issue named functions/files, open them and confirm the described behaviour is implemented.',
+  '   - If the PR added tests, locate them (grep the test dirs) and, when cheap, run the narrow suite for the',
+  '     touched area only. Paste the runner\'s own pass/fail marker — never paraphrase.',
+  '   - If it was a regression bug, search for the old pattern that was supposed to be removed; if it is still',
+  '     present, the fix did not take.',
+  '5. If a linter/test runner is configured, run it against the affected paths only (don\'t run the whole suite',
+  '   unless it is fast). Look for regressions tied to this fix.',
+  '',
+  '## Decide exactly one outcome',
+  '- VERIFIED — the fix matches the issue\'s intent AND is present in the current working tree. Quote the',
+  '  file:line evidence and (if any) the test that covers it.',
+  '- NOT_VERIFIED — missing, partial, reverted, or it never matched what the issue actually asked for. State the',
+  '  precise gap: what you expected (quote the criterion) vs. what is actually there now (file:line), and the',
+  '  later commit that removed it if applicable.',
+  '- SKIP_NEEDS_MANUAL — correctness CANNOT be determined from code alone: visual/pixel/layout bugs, animation',
+  '  timing, cross-browser/device rendering, end-to-end UX behind auth or third-party services, performance',
+  '  perception, audio/video, accessibility with assistive tech, anything needing a live external integration or',
+  '  staging environment. On this outcome DO NOTHING to the ticket — no comment, no transition, no reassignment.',
+  '  It only appears in the report so a human picks it up. A drive-by audit comment on a UX bug helps no one.',
+  '- SKIP_INSUFFICIENT — not enough signal to judge: no merged PR actually linked, ambiguous resolver, the',
+  '  referenced code/symbol is entirely gone with no traceable history. Report-only, like SKIP_NEEDS_MANUAL.',
+  '',
+  '## Be concrete',
+  'A vague comment ("looks fixed!" / "doesn\'t seem fixed") is worse than none — it pollutes the audit trail.',
+  'Every comment must name actual file paths, line numbers, commit SHAs, and quoted acceptance criteria.',
+  '',
+  '## Language rule (load-bearing)',
+  'Write the drafted comment in the language the ISSUE ITSELF is written in. Detect that language ONLY from the',
+  'prose the reporter typed in the issue title and description — the human sentences, not code identifiers or',
+  'field labels. IGNORE every environmental signal: the Jira/GitHub UI language, the browser/OS locale, the',
+  'account language, and project defaults. A French UI around an English issue body still means an English',
+  'comment. Translate the template\'s fixed headings and prose; keep code, paths, SHAs, and quoted criteria',
+  'verbatim. A French comment on an English issue (or vice-versa) is a defect.',
+].join('\n')
+
+// --- Comment templates (the load-bearing artifact) -------------------------
+const TEMPLATE_VERIFIED = [
+  '## Template — VERIFIED (closing comment). Fill every {{placeholder}}; never leave one in the output.',
+  '',
+  '## Audit: verified fixed — closing',
+  '',
+  'This issue was reviewed against the current state of the codebase and is confirmed resolved.',
+  '',
+  '**Fix landed in:**',
+  '- {{repo}}#{{pr_number}} ({{merge_commit_short_sha}}) by @{{resolver}}, merged {{merged_at}}',
+  '',
+  '**What was changed:**',
+  '- `{{file_path}}:{{line_range}}` — {{one-line summary of the change}}',
+  '',
+  '**How it satisfies the acceptance criteria:**',
+  '- "{{quoted criterion}}" → addressed by `{{file_path}}:{{line}}` ({{brief explanation}})',
+  '',
+  '**Tests covering this fix:**',
+  '- `{{test_file}}::{{test_name}}` — {{what it asserts}}',
+  '- (or: "No automated test added; manual verification only — recommend follow-up to add coverage.")',
+  '',
+  'Closing.',
+].join('\n')
+
+const TEMPLATE_NOT_VERIFIED = [
+  '## Template — NOT_VERIFIED (reopen / kick-back comment). Fill every {{placeholder}}.',
+  '',
+  '## Audit: fix could not be verified — re-opening',
+  '',
+  'This issue was marked resolved on {{resolved_date}} by @{{resolver}}, but the fix could not be confirmed against the current codebase.',
+  '',
+  '**What I checked:**',
+  '- Linked PR(s): {{repo}}#{{pr_number}} (merged {{merged_at}})',
+  '- Files reviewed in current tree: `{{file_path}}` ({{lines_read}})',
+  '- Tests run: {{test command and result}} — or "no tests run, see below"',
+  '',
+  '**What I expected to find (per the issue description):**',
+  '> {{quoted acceptance criterion or behavior described in the issue}}',
+  '',
+  '**What is actually present:**',
+  '- `{{file_path}}:{{line}}` — {{exactly what is there now and why it doesn\'t match}}',
+  '- (or: file/symbol referenced in the issue no longer exists in the tree — appears removed by `{{later_commit_sha}}`)',
+  '',
+  '**Reproduction (if applicable):**',
+  '1. {{steps to demonstrate the issue still occurs}}',
+  '',
+  '@{{resolver}} — reassigning to you. Could you either (a) point to the change that addresses this and re-resolve, or (b) re-open the work? If the issue was descoped or is no longer valid, please leave a comment and close as Won\'t Do.',
+].join('\n')
+
+function fmtPRs(prs) {
+  if (!Array.isArray(prs) || !prs.length) return '  (none linked — treat as SKIP_INSUFFICIENT unless other evidence of a fix exists)'
+  return prs.map(p => {
+    const files = Array.isArray(p.files) ? p.files.slice(0, 40).join(', ') : (p.files || 'unknown')
+    return [
+      '  - ' + (p.repo || input.ownerRepo || 'repo') + '#' + (p.number ?? '?') + ' — ' + (p.url || ''),
+      '    merge_commit: ' + (p.mergeCommit || 'unknown') + ', merged_at: ' + (p.mergedAt || 'unknown'),
+      '    author: @' + (p.author || 'unknown') + (p.mergedBy && p.mergedBy !== p.author ? ', merged_by: @' + p.mergedBy : ''),
+      '    files: ' + files,
+    ].join('\n')
+  }).join('\n')
+}
+
+function buildVerifyPrompt(c) {
+  const resolver = c.resolver || {}
+  const resolverName = resolver.login || resolver.displayName || resolver.name || 'unknown'
+  const plannedClose = tracker === 'jira'
+    ? ('transition to "' + (c.finalClosedStatus || 'the final closed status') + '"')
+    : 'close the issue (state=closed, reason=completed)'
+  const plannedReopen = tracker === 'jira'
+    ? ('transition back to "' + (c.initialStatus || 'the workflow start status') + '" and reassign to @' + resolverName)
+    : ('keep open, reassign to @' + resolverName + ', and remove any misleading fixed/resolved/done label')
+
+  return [
+    'You are auditing ONE resolved-but-not-closed ' + (tracker === 'jira' ? 'Jira issue' : 'GitHub issue') + '.',
+    'Verify whether the fix is genuinely present in the CURRENT working tree, then draft the audit comment.',
+    'You inherit the target repo as your working directory — `gh`, `git`, and the test runner all work here.',
+    '',
+    '## Issue ' + (c.id ?? '?') + ' — ' + (c.title || '(no title)'),
+    'URL: ' + (c.url || 'n/a'),
+    'Resolved on: ' + (c.resolvedDate || 'unknown') + ' by @' + resolverName,
+    '',
+    '### Issue body / acceptance criteria',
+    (c.body || '(empty — rely on the linked PR intent and report low confidence)').slice(0, 8000),
+    '',
+    '### Linked merged PR(s) — read each diff with `gh pr diff <num> --repo <owner>/<repo>`',
+    fmtPRs(c.mergedPRs),
+    '',
+    VERIFY_RULES,
+    '',
+    TEMPLATE_VERIFIED,
+    '',
+    TEMPLATE_NOT_VERIFIED,
+    '',
+    '## Planned action implied by each outcome (state it in your result, do NOT execute any write)',
+    '- VERIFIED → ' + plannedClose,
+    '- NOT_VERIFIED → ' + plannedReopen,
+    '- SKIP_* → no action; report only',
+    '',
+    'IMPORTANT: this is read-only verification. Do NOT post comments, close, transition, or reassign anything —',
+    'the skill does that later behind a single confirmation gate. Your job is to decide and DRAFT.',
+    '',
+    'Return structured output for this one issue.',
+  ].join('\n')
+}
+
+// --- Schema ----------------------------------------------------------------
+const RESULT_SCHEMA = {
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    id: { type: ['string', 'integer'] },
+    title: { type: 'string' },
+    outcome: { type: 'string', enum: ['VERIFIED', 'NOT_VERIFIED', 'SKIP_NEEDS_MANUAL', 'SKIP_INSUFFICIENT'] },
+    one_line: { type: 'string' },               // short report line (gap for NOT_VERIFIED, reason for SKIP)
+    comment_markdown: { type: 'string' },        // fully-filled comment, '' for SKIP_*
+    comment_language: { type: 'string' },        // detected language of the comment
+    planned_action: { type: 'string' },          // e.g. 'close', 'reopen+reassign', 'none'
+    resolver: { type: 'string' },                // login / accountId echoed back for the writer
+    files_reviewed: { type: 'array', items: { type: 'string' } },
+    tests_run: { type: 'string' },               // command + pasted pass/fail marker, or 'none'
+    evidence: { type: 'string' },                // file:line quotes backing the verdict
+  },
+  required: ['id', 'outcome', 'one_line', 'comment_markdown', 'planned_action'],
+}
+
+// ===========================================================================
+// PHASE: VERIFY — one agent per candidate, all in parallel (pipeline of a
+// single stage so each result streams back as soon as that issue is judged).
+// ===========================================================================
+phase('Verify')
+
+if (!candidates.length) {
+  log('No candidates passed in — nothing to verify.')
+  return { tracker, scope, results: [], counts: { total: 0 } }
+}
+
+log('Verifying ' + candidates.length + ' candidate ' + (tracker === 'jira' ? 'Jira issue(s)' : 'GitHub issue(s)') + ' in parallel against the working tree.')
+
+const results = await pipeline(
+  candidates,
+  (c) => agent(buildVerifyPrompt(c), {
+    label: 'verify:' + (c.id ?? '?'),
+    phase: 'Verify',
+    schema: RESULT_SCHEMA,
+    agentType: 'general-purpose',
+  }).then(r => {
+    // Echo back identity fields the skill needs to act, even if the agent omitted them.
+    if (!r) return null
+    return {
+      ...r,
+      id: r.id ?? c.id,
+      title: r.title || c.title,
+      url: c.url,
+      resolver: r.resolver || (c.resolver && (c.resolver.login || c.resolver.accountId || c.resolver.displayName)) || '',
+      mergedPRs: c.mergedPRs || [],
+    }
+  })
+)
+
+const clean = results.filter(Boolean)
+const counts = { total: candidates.length, verified: 0, not_verified: 0, skip_manual: 0, skip_insufficient: 0, errored: candidates.length - clean.length }
+for (const r of clean) {
+  if (r.outcome === 'VERIFIED') counts.verified++
+  else if (r.outcome === 'NOT_VERIFIED') counts.not_verified++
+  else if (r.outcome === 'SKIP_NEEDS_MANUAL') counts.skip_manual++
+  else counts.skip_insufficient++
+}
+
+log('Verified ' + counts.verified + ' · not-verified ' + counts.not_verified + ' · skip-manual ' + counts.skip_manual + ' · skip-insufficient ' + counts.skip_insufficient + (counts.errored ? ' · errored ' + counts.errored : ''))
+
+return { tracker, scope, results: clean, counts }


### PR DESCRIPTION
## Summary

This PR introduces deterministic fan-out workflows to two slow, per-item commands so that batches of issues are processed concurrently instead of one at a time. The heavy, repeatable per-issue work moves into `*.workflow.js` files, while the parts that need credentials, scope decisions, and a human-in-the-loop (PR creation, the `--apply` confirmation gate) stay in the command/skill. It also hardens the `auto-approve` workflow against an unguarded `grep` failure.

**Key changes:**

- `commands/work-issue.md`: add a single-vs-multiple mode select; two or more issue refs now run in parallel mode, each implemented by its own worktree-isolated agent. Documents preflight, workflow launch, result review, and the separate-vs-combined PR decision. Adds `Workflow` and `AskUserQuestion` to allowed-tools and updates the description/argument-hint.
- `commands/work-issue.workflow.js` (new): parallel implementation workflow — one worktree-isolated agent per issue (fetch, explore, implement, write+run tests as a hard gate, commit on a branch). Stops at "committed, tests green" and returns a per-issue result; does not push or open PRs.
- `skills/verify-resolved-issues/SKILL.md`: delegate per-issue verification (Steps 4-G / 6-J) to a fan-out workflow, with division of labour, launch args, and return shape documented. Adds `Workflow` and `Agent` to allowed-tools.
- `skills/verify-resolved-issues/verify-resolved-issues.workflow.js` (new): canonical per-issue verification logic — checklist, three-way outcome rules, SKIP guidance, comment templates, and language rule — returning a structured verdict per candidate.
- `.github/workflows/auto-approve.yml`: append `|| true` to the CODEOWNERS `grep` pipeline so a missing `*` line no longer aborts the step under `set -euo pipefail` (degrades to `is_owner=false`); remove the now-unused `ORG` env var.

## Types of changes

- [x] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: This repo has no local test harness; plugin markdown/YAML/JS are validated by CI linters (markdownlint, yamllint, actionlint), and `*.workflow.js` files are excluded from eslint/semgrep by design.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified