### PR TITLE
Repoint skill workflow paths and improve code-review-deep coverage and gating

### DIFF
--- a/skills/code-review-deep/SKILL.md
+++ b/skills/code-review-deep/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: code-review-deep
 description: "Exhaustive multi-phase code audit using parallel agents (security, dependencies, code quality, infrastructure, tests, and more). Use when the user wants a deep or thorough code review, a comprehensive audit, a security-and-quality sweep of a repo or subsystem, or a multi-agent review that goes beyond the current diff. Optionally scoped to a path or subsystem."
-allowed-tools: Bash(git:*), Bash(gh:*), Bash(jq:*), Bash(awk:*), Bash(cat:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(ls:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, TodoWrite, Workflow, Agent, AskUserQuestion, WebSearch, WebFetch, mcp__github__*, mcp__context7__*
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(jq:*), Bash(awk:*), Bash(cat:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(ls:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, TodoWrite, Workflow, Agent, Skill, AskUserQuestion, WebSearch, WebFetch, mcp__github__*, mcp__context7__*
 ---
 
 # Deep Code Review (Workflow-Orchestrated)
 
-You are a senior staff engineer running an exhaustive code audit. The heavy fan-out — Phase 1 scans, Phase 2 deep analysis, Phase 3 adversarial validation, and the Phase 3.5 confidence filter — runs as a **deterministic workflow** (`code-review-deep.workflow.js`). Your job in this command is the work that needs judgment and a human in the loop: the pre-flight check, gathering repository context, invoking the workflow, and rendering the final report from the structured data it returns.
+You are a senior staff engineer running an exhaustive code audit. The heavy fan-out — Phase 1 scans, Phase 2 deep analysis, Phase 3 adversarial validation, and the Phase 3.5 confidence filter — runs as a **deterministic workflow** (`code-review-deep.workflow.js`). Your job in this command is the work that needs judgment and a human in the loop: the pre-flight check, gathering repository context, invoking the workflow, optionally running the dedicated documentation skills in review-only mode when the user opts in (Step 3.5), and rendering the final report from the structured data it returns.
 
 **Balance criticism with recognition.** A good review acknowledges what the team does well. The workflow returns `positives` from every agent — surface them in the report. It should feel constructive, not purely negative.
 
-**Where the analysis rules live.** The agent prompts, governance rules, exclusions, the adversarial-validation checklist, and the per-severity confidence thresholds are all defined in `${CLAUDE_PLUGIN_ROOT}/commands/code-review-deep.workflow.js`. To tune *what the review looks for*, edit that file — not this command.
+**Where the analysis rules live.** The agent prompts, governance rules, exclusions, the adversarial-validation checklist, and the per-severity confidence thresholds are all defined in `${CLAUDE_PLUGIN_ROOT}/skills/code-review-deep/code-review-deep.workflow.js`. To tune *what the review looks for*, edit that file — not this skill.
 
 ## Run from the target repo's directory (direnv)
 
@@ -90,7 +90,7 @@ Invoke the workflow with the gathered context. Pass the scope the user provided 
 
 ```text
 Workflow({
-  scriptPath: "${CLAUDE_PLUGIN_ROOT}/commands/code-review-deep.workflow.js",
+  scriptPath: "${CLAUDE_PLUGIN_ROOT}/skills/code-review-deep/code-review-deep.workflow.js",
   args: {
     scope: "<the user-provided scope, or 'the whole repository'>",
     repoContext: {
@@ -110,9 +110,9 @@ Workflow({
 | Phase | Agents | Purpose |
 | ----- | ------ | ------- |
 | Scan | 3 parallel `Explore` | Tech stack (+ applicability booleans), config inventory, structure |
-| Analyze | 7–11 parallel `general-purpose` | Core agents always run; backend / infra-compliance / i18n-ml / prompt-artifacts run only when Phase 1 flags them |
-| Verify | N parallel (≤10 findings each) | Adversarial validation that tries to **disprove** each finding, with a 0–100 confidence score |
-| Filter | (in-script) | Per-severity confidence thresholds: Critical ≥40, High ≥60, Medium ≥65, Low ≥75, Info ≥80 |
+| Analyze | 8–12 parallel `general-purpose` | Core agents always run (security, quality, bugs, testing, deps, repo-ci, docs, consistency); backend / infra-compliance / i18n-ml (i18n + accessibility) / prompt-artifacts run only when Phase 1 flags them |
+| Verify | N parallel (≤5 findings each) | Adversarial validation that tries to **disprove** each finding, with a 0–100 confidence score |
+| Filter | (in-script) | Per-severity confidence thresholds (aligned to the validator's 0/25/50/75/100 anchor grid): Critical ≥25, High ≥50, Medium ≥50, Low ≥50, Info ≥75 |
 
 The workflow runs in the background and notifies you on completion. It **returns a structured object**:
 
@@ -132,6 +132,28 @@ If the user explicitly asks to change strictness (e.g. "be aggressive — keep e
 
 ---
 
+## STEP 3.5 — DEEP DOCUMENTATION REVIEW (opt-in, review-only)
+
+**This step is gated OFF by default.** The workflow's `docs` agent already covers documentation presence, stubs, and configuration on every run — that is the default. Skip this entire step **unless the user explicitly opts in** to a deep documentation-content review, e.g. by passing a `--docs` / `--deep-docs` flag or asking in words to "also review the README / architecture doc / user guide content", "include a documentation review", or similar. If the user did not ask for it, go straight to Step 4 and treat the three doc skills as **not run** in the Review Coverage checklist.
+
+When opted in, deep-review the documentation with the three dedicated skills, then fold their findings into this report. These skills verify doc **content against the code**, which the workflow does not.
+
+Invoke each via the **Skill** tool in **review-only** mode — they must NOT create or modify any files during a deep review; we only want their findings:
+
+- `co-dev:review-readme`
+- `co-dev:review-architecture`
+- `co-dev:review-user-guide`
+
+For each, pass an explicit review-only instruction as the skill's args, e.g.:
+
+> Review-only mode for a larger code audit: analyze and report findings, but DO NOT create, write, or edit README.md / docs/architecture.md / docs/user-guide.md or any other file. Return your findings only — the deep code review will fold them into `docs/code-review.md`.
+
+Each skill self-exempts when its document doesn't apply (e.g. no end-user product → the user-guide skill skips). Treat a skip as **N/A**, not a failure.
+
+**Fold the results in:** translate each skill's reported issues into the standard finding format under the report's Documentation area, using `DOC-*` IDs, with severity per the skill's own assessment and the file references it cites. Deduplicate against the workflow's `docs` findings (same file + root cause). In the report, note that deep documentation review was performed by the review-readme / review-architecture / review-user-guide skills. Do not let these skills write their own doc files or a separate report.
+
+---
+
 ## STEP 4 — REPORT GENERATION
 
 Operate on the workflow's return value. **Pre-report verification:** confirm the workflow completed and every `kept` finding has a `code_quoted` and `confidence_score`. If the workflow returned nothing (e.g. it was cancelled), stop and report that rather than inventing findings.
@@ -139,11 +161,12 @@ Operate on the workflow's return value. **Pre-report verification:** confirm the
 Then:
 
 1. Take `kept` as the main findings; `filtered` becomes the "Filtered (Low Confidence)" appendix.
-2. Deduplicate overlapping findings (same file + same root cause across agents).
-3. Sort by severity (Critical → High → Medium → Low → Info).
-4. Write `docs/code-review.md` (create the directory if needed).
-5. Include `positives` (grouped by area) and the quantitative `counts` in the report.
-6. Build the **Review Coverage** checklist from `agents_run` (mark agents that did not run as N/A, not as failures).
+2. If Step 3.5 ran, merge in its `DOC-*` findings as regular findings; if it was skipped (the default), there are none to merge.
+3. Deduplicate overlapping findings (same file + same root cause across agents, and vs. any Step 3.5 doc findings).
+4. Sort by severity (Critical → High → Medium → Low → Info).
+5. Write `docs/code-review.md` (create the directory if needed).
+6. Include `positives` (grouped by area) and the quantitative `counts` in the report.
+7. Build the **Review Coverage** checklist from `agents_run`; add the three doc skills only when Step 3.5 ran (mark agents/skills that did not run, were not opted into, or self-exempted as N/A, not as failures).
 
 Do NOT include internal workflow/phase tracking in the final report.
 
@@ -242,7 +265,7 @@ How to address it.
 
 ## ✅ Positive Observations & Strengths
 
-Highlight what the team is doing well, organized by area (Architecture, Code Quality, Security, Testing, DevOps/CI/CD, Documentation, Dependencies, IaC, Performance, Observability, API Design, Compliance, Configuration, Error Handling). Be specific about which files/patterns demonstrate this. Skip sections that don't apply.
+Highlight what the team is doing well, organized by area (Architecture, Code Quality, Consistency, Security, Testing, DevOps/CI/CD, Documentation, Dependencies, IaC, Performance, Observability, API Design, Compliance, Configuration, Error Handling, Internationalization, Accessibility). Be specific about which files/patterns demonstrate this. Skip sections that don't apply.
 
 ---
 
@@ -314,6 +337,8 @@ Highlight what the team is doing well, organized by area (Architecture, Code Qua
 | I18N | Internationalization |
 | BUG | Bug Patterns |
 | COMPAT | Backwards Compatibility |
+| CONS | Consistency / Convention Drift |
+| A11Y | Accessibility |
 | PLUGIN | Claude Code Plugin Artifacts (commands/skills/agents/hooks/MCP) |
 | PROMPT | LLM Prompt Engineering (embedded prompts) |
 
@@ -369,6 +394,8 @@ Always include `code-review` plus one category label:
 | BUG-* | bug-patterns |
 | COMPAT-* | backwards-compat |
 | CFG-* | configuration |
+| CONS-* | consistency |
+| A11Y-* | accessibility |
 | PLUGIN-* | plugin-artifacts |
 | PROMPT-* | llm-prompts |
 

--- a/skills/code-review-deep/code-review-deep.workflow.js
+++ b/skills/code-review-deep/code-review-deep.workflow.js
@@ -13,12 +13,12 @@ export const meta = {
 // analysis behaviour: the Phase 1 scout prompts, the Phase 2 analysis prompts,
 // the Phase 3 adversarial-validation checklist, the governance rules, the
 // exclusions, and the per-severity confidence thresholds all live here. Edit
-// THIS FILE to tune what the review looks for. The command markdown only
+// THIS FILE to tune what the review looks for. The skill markdown only
 // handles preflight (existing-report check, repo-context gathering) and the
 // final report rendering from the structured data this workflow returns.
 //
-// Invoked by commands/code-review-deep.md via:
-//   Workflow({ scriptPath: "${CLAUDE_PLUGIN_ROOT}/commands/code-review-deep.workflow.js",
+// Invoked by skills/code-review-deep/SKILL.md via:
+//   Workflow({ scriptPath: "${CLAUDE_PLUGIN_ROOT}/skills/code-review-deep/code-review-deep.workflow.js",
 //              args: { repoContext: {...}, scope: "..." } })
 // ---------------------------------------------------------------------------
 
@@ -27,9 +27,14 @@ const repoContext = input.repoContext || {}
 const scope = input.scope || 'the whole repository'
 
 // --- Per-severity confidence thresholds (Phase 3.5) ------------------------
-// Critical/High survive at lower confidence (cost of a miss is high); Medium/
-// Low/Info need higher confidence so stochastic re-runs stay deterministic.
-const SEV_THRESHOLDS = { critical: 40, high: 60, medium: 65, low: 75, info: 80 }
+// IMPORTANT: the validator scores on the anchor grid 0/25/50/75/100 (see
+// buildVerifyPrompt). Thresholds MUST land ON those anchors — a threshold of
+// 65 silently rounds a "50 = verified real but minor" finding up into the
+// reject bucket, which is why the main report used to come back empty while
+// the appendix filled up. Keep every value in {25, 50, 75}.
+// Critical/High survive at lower confidence (cost of a miss is high); Low/Info
+// need a higher bar so stochastic re-runs stay deterministic.
+const SEV_THRESHOLDS = { critical: 25, high: 50, medium: 50, low: 50, info: 75 }
 
 function normSev(s) {
   const t = String(s || '').toLowerCase()
@@ -302,6 +307,9 @@ const A_DOCS = {
   key: 'docs', idPrefix: 'DOC',
   prompt: [
     'Project documentation AND configuration management.',
+    'SCOPE NOTE: deep content-accuracy review of README.md, docs/architecture.md, and docs/user-guide.md is an OPTIONAL, opt-in pass',
+    'handled by dedicated skills after this workflow (off by default). Regardless of whether it runs, this agent limits documentation',
+    'work to: presence, empty/stub detection, required-files below, and configuration management. Do the configuration checks in full.',
     'Documentation - required files:',
     '- README.md sections: project name with build badge, table of contents, overview, installation, usage, contributing.',
     '- docs/architecture.md (standard): TOC, architecture diagram, software units, SOUP, critical algorithms, risk controls.',
@@ -322,6 +330,37 @@ const A_DOCS = {
     '4. Feature flags: inconsistent naming, no cleanup of old flags, undocumented dependencies.',
     '5. Platform-specific: iOS xcconfig per environment; Android buildConfigField per flavor; Web client-side env exposure',
     '   (NEXT_PUBLIC_, VITE_), build-time vs runtime.',
+  ].join('\n'),
+}
+
+const A_CONSISTENCY = {
+  key: 'consistency', idPrefix: 'CONS',
+  prompt: [
+    'Review CONSISTENCY WITH THE REST OF THE CODEBASE — does the code look like it was written by the same team, following',
+    'the conventions already established here? Establish the repo\'s dominant patterns FIRST (read a representative sample of',
+    'existing code), then flag code that diverges from them without a reason. This is about uniformity, not absolute rules:',
+    'the yardstick is "what does the rest of this repo already do?"',
+    'Do NOT duplicate other agents: pure duplication metrics + method/class size are Agent B (quality); silent-failure counts',
+    'are Agent C (bugs); dependency duplicates are the deps agent; hardcoded user-facing strings / i18n routing are the i18n',
+    'agent. Here, focus on CONVENTION DRIFT:',
+    '1. Reinventing existing building blocks: a new helper/util/service that re-implements something the repo already provides',
+    '   (an existing formatter, validator, HTTP wrapper, date util, form/section helper, base class). Grep for the existing',
+    '   one and cite it. Reusing the established helper is the fix.',
+    '2. Naming drift: identifiers, files, DB columns, routes, event/constant names that break the repo\'s prevailing casing or',
+    '   naming scheme (camelCase vs snake_case, handler vs controller, get_x vs fetch_x). Cite the majority convention.',
+    '3. Structural drift: a file/module placed outside the established folder layout, or a layer boundary crossed the way the',
+    '   rest of the repo does not (e.g. a view hitting the DB directly when every other view goes through a repository).',
+    '4. Divergent approach for a solved problem: a second way of doing something the codebase already standardizes — a',
+    '   different HTTP client, state-management approach, error-wrapping style, logging call, config-access pattern, or test',
+    '   scaffolding than the prevailing one. Report the two variants and which is dominant.',
+    '5. UI/component drift (if applicable): bespoke markup/components where the repo has a shared component / design-system /',
+    '   form helper for that exact thing; inconsistent spacing/props/variants versus the established components.',
+    '6. Idiom drift: manual code where the repo elsewhere uses a cleaner idiom already (framework helper, language feature),',
+    '   or formatting/ordering that the rest of the repo does not use.',
+    'For every finding, cite BOTH the divergent code AND at least one existing example of the established convention',
+    '(file:line). A finding with no established-convention citation is just opinion — do not raise it. Severity is usually',
+    'Low/Medium (maintainability); escalate only when the drift causes real bugs or bypasses a safety pattern. Acknowledge',
+    'strong consistency in positives[].',
   ].join('\n'),
 }
 
@@ -381,12 +420,24 @@ const A_INFRA = {
 const A_LOCALE_ML = {
   key: 'i18n-ml', idPrefix: 'I18N',
   prompt: [
-    'Localization AND AI/ML practices (only because user-facing UI or ML was detected). Run only the relevant sub-section.',
-    'i18n (if user-facing UI): hardcoded user-facing strings, concatenation that breaks translation, missing translation keys;',
-    'missing plural forms, incorrect rules for non-English; date/time/currency not locale-aware, hardcoded number/date formats;',
-    'RTL: hardcoded left/right vs leading/trailing (iOS), missing supportsRtl (Android), margin-left vs margin-inline-start (CSS);',
-    'platform: iOS strings in Localizable.strings/.xcstrings, NSLocalizedString usage; Android @string/ not hardcoded, translations in',
-    'values-XX/; Web i18n library usage, no template literals with embedded text; workflow: string extraction in CI, missing translations flagged.',
+    'Localization, ACCESSIBILITY, AND AI/ML practices (only because user-facing UI or ML was detected). Run only the relevant sub-sections.',
+    'i18n uniformity (if user-facing UI) - the guiding question is "does EVERY user-facing string go through the project\'s',
+    'translation mechanism, the way the rest of the app does?" First identify the project\'s i18n mechanism (e.g. I18n.t / t(),',
+    'NSLocalizedString, @string/, an i18n library) and its locale files, then:',
+    '- Hardcoded user-facing strings that bypass it - flag each with file:line and the key it SHOULD use. Report an exact count',
+    '  ("X hardcoded user-facing strings across Y files") and the percentage routed through i18n if estimable.',
+    '- Keys referenced in code but MISSING from the locale/translation files, and (INFO) keys defined but never referenced.',
+    '- Partial-locale coverage: a key present in one locale but missing in others.',
+    '- Concatenation / interpolation that breaks translation word order; missing plural forms or wrong plural rules for non-English;',
+    '  date/time/currency/number not locale-aware (hardcoded formats).',
+    '- RTL: hardcoded left/right vs leading/trailing (iOS), missing supportsRtl (Android), margin-left vs margin-inline-start (CSS).',
+    '- Platform specifics: iOS Localizable.strings/.xcstrings + NSLocalizedString; Android @string/ + values-XX/; Web i18n library,',
+    '  no template literals with embedded text; workflow: string extraction in CI, missing translations flagged.',
+    'Accessibility (if user-facing UI) - prefix A11Y: images/icons without alt/contentDescription/accessibilityLabel; form inputs',
+    'without associated labels; buttons/links with no accessible name (icon-only controls); non-semantic clickable elements (div',
+    'onClick) without role/keyboard handlers; missing focus management / keyboard navigation; color-only signaling of state;',
+    'insufficient contrast where declared; missing lang attribute / dynamic-type or font-scaling support; decorative media not',
+    'hidden from assistive tech. Cite file:line; be consistent with the platform\'s a11y API. Use prefix A11Y for these findings.',
     'AI/ML (if ML frameworks detected): reproducibility (random seeds set, model versioning, experiment tracking, no hardcoded',
     'hyperparameters); data (schema/validation, train/test split verification, data leakage, feature versioning); model management',
     '(registry, metadata, A/B testing, rollback); security (models from untrusted sources can execute arbitrary code on load - flag any',
@@ -426,7 +477,7 @@ const A_PROMPTS = {
   ].join('\n'),
 }
 
-const CORE_AGENTS = [A_SECURITY, A_QUALITY, A_BUGS, A_TESTING, A_DEPS, A_REPO_CI, A_DOCS]
+const CORE_AGENTS = [A_SECURITY, A_QUALITY, A_BUGS, A_TESTING, A_DEPS, A_REPO_CI, A_DOCS, A_CONSISTENCY]
 
 // --- Phase 3 adversarial validation prompt ---------------------------------
 function buildVerifyPrompt(findings) {
@@ -447,8 +498,13 @@ function buildVerifyPrompt(findings) {
     'Findings to validate (JSON):',
     JSON.stringify(list, null, 2),
     '',
-    'For EACH finding, complete ALL of these checks. If you cannot complete a check, REJECT.',
-    '1. Quote the actual code - read the file at the location and quote 5-10 lines of context. No quote = REJECT.',
+    'For EACH finding, work through ALL of these checks. A finding survives only if NONE of the checks disprove it.',
+    'Do NOT auto-reject merely because a check was inconclusive — reject on a positive disproof (a mitigating factor',
+    'you actually found), and otherwise let the confidence score carry the uncertainty.',
+    '1. Quote the actual code - read the file at the location and quote 5-10 lines of context. If you genuinely cannot',
+    '   open the file in this pass (batched review, path moved), do NOT auto-reject: proceed with the remaining checks and',
+    '   cap confidence_score at 50, noting in confidence_rationale that the quote is missing. Only an EMPTY/nonexistent file',
+    '   or a quote that contradicts the finding is a REJECT.',
     '2. Check for mitigating factors - wrappers, middleware, base classes, config files (.env, config/, settings), related files',
     '   providing the missing functionality, handling at a different layer (infra, framework, platform).',
     '3. Check for existing handling elsewhere - grep for related patterns; check imports for libraries that handle this automatically.',
@@ -466,11 +522,13 @@ function buildVerifyPrompt(findings) {
     '   addressed? Eager-eye findings (only noticed on the first skim) are opinion, not load-bearing. If you would not re-flag it on a',
     '   second pass, REJECT. This is what keeps re-runs deterministic across stochastic sampling.',
     '',
-    'REJECT if: any mitigating factor exists, the issue is handled elsewhere, you cannot quote the code, repo settings address it, a',
-    'senior engineer would not flag it, the choice is deliberate given repo context, or it would not be re-flagged on a second read.',
-    'CONFIRM only if all checks fail to disprove the finding.',
+    'REJECT if: any mitigating factor exists, the issue is handled elsewhere, the file is empty/nonexistent or the quoted code',
+    'contradicts the finding, repo settings address it, a senior engineer would not flag it, the choice is deliberate given repo',
+    'context, or it would not be re-flagged on a second read. Being unable to open the file in a batched pass is NOT grounds to',
+    'reject — cap the confidence at 50 instead. CONFIRM if the checks fail to disprove the finding.',
     '',
-    'Confidence score (CONFIRMs only): 0 = false positive / pre-existing; 25 = might be real but unverified or purely stylistic;',
+    'Confidence score (CONFIRMs only): output ANY integer 0-100 and interpolate between these anchors — do NOT snap only to',
+    'the round numbers. 0 = false positive / pre-existing; 25 = might be real but unverified or purely stylistic;',
     '50 = verified real but minor/rare; 75 = double-checked, real, likely to be hit, OR explicitly violates a project convention;',
     '100 = certain, evidence directly confirms it, will happen frequently. REJECTED = 0. CONFIRMED must score >= 25.',
     '',
@@ -581,7 +639,9 @@ log('Phase 1 done. Running ' + selected.length + ' analysis agents: ' + selected
 // ===========================================================================
 // PHASE 2 -> PHASE 3 as a pipeline: each agent's findings are adversarially
 // verified as soon as that agent returns (no global barrier). Verification is
-// batched up to 10 findings per validator to preserve cache reuse / cost.
+// batched up to 5 findings per validator: small enough that the validator can
+// actually open and quote every file in the batch (larger batches starved the
+// per-finding code-read budget and caused false rejections).
 // ===========================================================================
 phase('Analyze')
 const reviewed = await pipeline(
@@ -592,7 +652,7 @@ const reviewed = await pipeline(
     const issues = (review && Array.isArray(review.issues)) ? review.issues : []
     if (!issues.length) return { agentDef, review, verdicts: [] }
     const batches = await parallel(
-      chunk(issues, 10).map((group, i) => () =>
+      chunk(issues, 5).map((group, i) => () =>
         agent(buildVerifyPrompt(group), { label: 'verify:' + agentDef.key + '#' + i, phase: 'Verify', schema: VERDICT_SCHEMA, agentType: 'general-purpose' })
       )
     )

--- a/skills/work-issue/SKILL.md
+++ b/skills/work-issue/SKILL.md
@@ -92,7 +92,7 @@ Detect the tracker once (`gh repo view --json hasIssuesEnabled --jq '.hasIssuesE
 
 ```text
 Workflow({
-  scriptPath: "${CLAUDE_PLUGIN_ROOT}/commands/work-issue.workflow.js",
+  scriptPath: "${CLAUDE_PLUGIN_ROOT}/skills/work-issue/work-issue.workflow.js",
   args: {
     defaultBranch: "<DEFAULT_BRANCH>",
     repoRoot: "<REPO_ROOT>",
@@ -111,7 +111,7 @@ Each agent fetches its issue, creates branch `issue-<n>` (GitHub) or `<KEY>` upp
 }
 ```
 
-The implementation rules (branch naming, issue-type → commit prefix, the test hard-gate, no-signature commits) live in `${CLAUDE_PLUGIN_ROOT}/commands/work-issue.workflow.js` — edit that file to tune the parallel path.
+The implementation rules (branch naming, issue-type → commit prefix, the test hard-gate, no-signature commits) live in `${CLAUDE_PLUGIN_ROOT}/skills/work-issue/work-issue.workflow.js` — edit that file to tune the parallel path.
 
 ### P3 — Review results
 

--- a/skills/work-issue/work-issue.workflow.js
+++ b/skills/work-issue/work-issue.workflow.js
@@ -9,7 +9,7 @@ export const meta = {
 // ---------------------------------------------------------------------------
 // Parallel path for the work-issue command. Used ONLY when the user passes
 // more than one issue. A single issue still runs the normal interactive flow
-// in work-issue.md (clarifying-questions gate, architecture choice, per-step
+// in SKILL.md (clarifying-questions gate, architecture choice, per-step
 // approval) — those gates need a human and don't fit a background workflow.
 //
 // Each issue is implemented by its OWN agent in its OWN git worktree
@@ -22,8 +22,8 @@ export const meta = {
 // does NOT open PRs — the command asks the user "separate PRs or one combined
 // PR?" once, after this returns, and drives create-pr accordingly.
 //
-// Invoked by commands/work-issue.md via:
-//   Workflow({ scriptPath: "${CLAUDE_PLUGIN_ROOT}/commands/work-issue.workflow.js",
+// Invoked by skills/work-issue/SKILL.md via:
+//   Workflow({ scriptPath: "${CLAUDE_PLUGIN_ROOT}/skills/work-issue/work-issue.workflow.js",
 //              args: { issues: [{ ref, tracker }], defaultBranch, repoRoot } })
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to the command-to-skill conversion (#56). The `code-review-deep` and `work-issue` workflows still referenced their old `commands/` locations in prose, invocation examples, and header comments; this repoints every reference to the new `skills/<name>/` paths so the docs match reality. Alongside the path fixes, this hardens the `code-review-deep` audit: it fixes a scoring bug that emptied the main report, adds new review dimensions, and gates the expensive deep-documentation pass behind explicit opt-in.

**Key changes:**

- Repoint all stale `commands/*.workflow.js` and `commands/*.md` references to `skills/code-review-deep/` and `skills/work-issue/` in both SKILL.md files and both workflow.js header comments.
- Fix the Phase 3.5 confidence thresholds: align them to the validator's 0/25/50/75/100 anchor grid (Critical 25, High/Medium/Low 50, Info 75) so verified-but-minor findings no longer round up into the reject bucket and leave the main report empty.
- Add a new core `consistency` (CONS) analysis agent that flags convention/idiom/structural drift against the repo's established patterns, requiring a cited existing-convention example per finding.
- Extend the `i18n-ml` agent with an accessibility (A11Y) sub-section and stronger i18n-uniformity guidance; add CONS and A11Y to the report category and label tables.
- Make the adversarial validator tolerant of un-openable files in batched passes (cap confidence at 50 instead of auto-rejecting), and shrink verify batches from 10 to 5 findings so each file can actually be read and quoted.
- Add an opt-in, review-only deep documentation pass (Step 3.5) invoking the review-readme/review-architecture/review-user-guide skills, off by default, with the workflow's `docs` agent scoped to presence/stubs/config on every run.

## Types of changes

- [x] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: This repo has no test harness; it is markdown skill definitions and workflow.js orchestration scripts validated by CI linters only.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified