### PR TITLE
Document Azure official plugin in Complementary Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ These official plugins from the `claude-plugins-official` marketplace pair well 
 | `vercel`               | Vercel's official plugin — deployment ops via the Vercel MCP, plus `/deploy` `/env` `/status` commands and a deployment-expert agent                                                  | `claude plugin install vercel@claude-plugins-official`                                                                |
 | `huggingface-skills`   | Hugging Face's official skills — build, train, evaluate, and use open-source models, datasets, and Spaces (HF CLI, trainers, evaluation, Gradio). For ML/model work.                  | `claude plugin install huggingface-skills@claude-plugins-official`                                                    |
 | `sentry`               | Sentry error monitoring — access error reports, analyze stack traces, search issues, debug production errors, and set up Sentry SDKs                                                  | `claude plugin install sentry@claude-plugins-official`                                                                |
+| `azure`                | Microsoft's official Azure plugin — bundles the Azure MCP + ~28 ops skills: list resources, deploy, validate, diagnose, RBAC/Entra, and optimize costs across 50+ services            | `claude plugin install azure@claude-plugins-official`                                                                 |
 
 > The `stripe` plugin bundles Stripe's own MCP and agent tools, so you do **not** need a separate
 > `claude mcp add stripe`. For local webhook
@@ -417,6 +418,9 @@ These official plugins from the `claude-plugins-official` marketplace pair well 
 > The `sentry` plugin is skill-based (SDK setup + debug workflows). For CLI operations — release tracking and
 > source-map uploads — install the Sentry CLI: `brew install sentry-cli` (also packaged as the `sentry-cli`
 > plugin).
+>
+> The `azure` plugin bundles the Azure MCP (`@azure/mcp`), so no separate `claude mcp add` is needed. It
+> authenticates with your Azure CLI credentials — install it with `brew install azure-cli` then `az login`.
 >
 > `document-skills` lives on Anthropic's own `anthropic-agent-skills` marketplace (not
 > `claude-plugins-official`), so it needs the one-time `claude plugin marketplace add` step above. It is


### PR DESCRIPTION
## Summary

Adds a Complementary Plugins row for **Microsoft's official Azure plugin** (`azure@claude-plugins-official`, source `microsoft/azure-skills`) — the Azure analog to co-dev's `aws`/`gcloud` skills, filling a gap where co-dev had no Azure coverage.

- **What it bundles:** the official Azure MCP (`@azure/mcp`) + ~28 ops skills — list/visualize resources, deploy/validate/migrate, diagnostics & reliability, cost & quotas, RBAC/Entra identity, AKS/storage/messaging/Kusto, and Azure AI.
- **CLI note:** the plugin authenticates with Azure CLI credentials — `brew install azure-cli` then `az login`. The MCP is bundled, so no separate `claude mcp add` is needed.

## Validation
- `markdownlint-cli2` clean on the README.