### PR TITLE
Remove contradictory burden of proof from the deep-review verifier

### DIFF
--- a/skills/code-review-deep/code-review-deep.workflow.js
+++ b/skills/code-review-deep/code-review-deep.workflow.js
@@ -524,8 +524,10 @@ function buildVerifyPrompt(findings) {
     description: f.description,
   }))
   return [
-    'Mission: try to DISPROVE each finding below. Phase 2 was biased toward finding issues; you must be biased toward REJECTION.',
-    'Assume every finding is a false positive until proven otherwise.',
+    'Mission: try to DISPROVE each finding below. Phase 2 was biased toward finding issues;',
+    'your job is to hunt for the mitigating factor that kills each one. REJECT only when you',
+    'found a specific disproof and can name it. When you found none, CONFIRM and let the',
+    'confidence score carry your uncertainty. Inconclusive is not a rejection.',
     '',
     repoBlock,
     '',


### PR DESCRIPTION
# Summary

Finding PR-212fb2 (high, conflicts).

`buildVerifyPrompt` in `skills/code-review-deep/code-review-deep.workflow.js` stated two opposite burdens of proof eight lines apart. It opened with:

> Mission: try to DISPROVE each finding below. Phase 2 was biased toward finding issues; you must be biased toward REJECTION.
> Assume every finding is a false positive until proven otherwise.

which puts the onus on the finding to prove itself, but eleven lines later the same prompt said:

> Do NOT auto-reject merely because a check was inconclusive — reject on a positive disproof (a mitigating factor you actually found), and otherwise let the confidence score carry the uncertainty.

which puts the onus on the verifier to disprove. Which framing wins varied between runs, so the confirmed-finding count was not reproducible.

The second framing is the intended behaviour: check 1 in the same prompt already tells the model to cap `confidence_score` at 50 rather than reject when it cannot read a file. This change therefore replaces only the two opening lines with framing that agrees with the disproof-based rule — REJECT only on a specific, nameable disproof; when none is found, CONFIRM and let the confidence score carry the uncertainty; inconclusive is not a rejection.

Nothing else in the file changed. In particular the confidence-score anchor text near the end of `buildVerifyPrompt` and the `SEV_THRESHOLDS` block are untouched — a sibling PR (`fix/code-review-deep-confidence-anchors`) owns those, and both land in the same function, so the two should be reviewed together.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: the change is prompt text inside a workflow script; there is no test harness for prompt wording, so verification was `node --check` on the modified file plus a full read of the diff.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The change is confined to the four lines that open the phase 3 verification prompt. The one judgement call was to keep the existing "try to DISPROVE each finding" mission sentence rather than rewrite the whole opening, so the prompt's overall skeptical posture is preserved while the contradictory "assume false positive until proven otherwise" default is removed.
