### PR TITLE
Pin verifier confidence to the anchor grid the thresholds assume

### DIFF
--- a/skills/code-review-deep/code-review-deep.workflow.js
+++ b/skills/code-review-deep/code-review-deep.workflow.js
@@ -27,11 +27,15 @@ const repoContext = input.repoContext || {}
 const scope = input.scope || 'the whole repository'
 
 // --- Per-severity confidence thresholds (Phase 3.5) ------------------------
-// IMPORTANT: the validator scores on the anchor grid 0/25/50/75/100 (see
-// buildVerifyPrompt). Thresholds MUST land ON those anchors — a threshold of
-// 65 silently rounds a "50 = verified real but minor" finding up into the
-// reject bucket, which is why the main report used to come back empty while
-// the appendix filled up. Keep every value in {25, 50, 75}.
+// IMPORTANT: the validator scores on the anchor grid 0/25/50/75/100. That grid
+// is not an assumption — it is enforced twice: buildVerifyPrompt instructs the
+// validator to output exactly one anchor, and VERDICT_SCHEMA pins
+// confidence_score to enum [0, 25, 50, 75, 100] so an off-grid value fails
+// validation instead of being silently mis-bucketed here. Thresholds MUST land
+// ON those anchors — a threshold of 65 silently rounds a "50 = verified real
+// but minor" finding up into the reject bucket, which is why the main report
+// used to come back empty while the appendix filled up. Keep every value in
+// {25, 50, 75}.
 // Critical/High survive at lower confidence (cost of a miss is high); Low/Info
 // need a higher bar so stochastic re-runs stay deterministic.
 const SEV_THRESHOLDS = { critical: 25, high: 50, medium: 50, low: 50, info: 75 }
@@ -561,8 +565,9 @@ function buildVerifyPrompt(findings) {
     'context, or it would not be re-flagged on a second read. Being unable to open the file in a batched pass is NOT grounds to',
     'reject — cap the confidence at 50 instead. CONFIRM if the checks fail to disprove the finding.',
     '',
-    'Confidence score (CONFIRMs only): output ANY integer 0-100 and interpolate between these anchors — do NOT snap only to',
-    'the round numbers. 0 = false positive / pre-existing; 25 = might be real but unverified or purely stylistic;',
+    'Confidence score (CONFIRMs only): output EXACTLY one of 0, 25, 50, 75, 100. Do not interpolate;',
+    'pick the nearest anchor and justify the choice in confidence_rationale.',
+    '0 = false positive / pre-existing; 25 = might be real but unverified or purely stylistic;',
     '50 = verified real but minor/rare; 75 = double-checked, real, likely to be hit, OR explicitly violates a project convention;',
     '100 = certain, evidence directly confirms it, will happen frequently. REJECTED = 0. CONFIRMED must score >= 25.',
     '',
@@ -633,7 +638,7 @@ const VERDICT_SCHEMA = {
         properties: {
           finding_id: { type: 'string' },
           decision: { type: 'string', enum: ['REJECT', 'CONFIRM'] },
-          confidence_score: { type: 'integer' },
+          confidence_score: { type: 'integer', enum: [0, 25, 50, 75, 100] },
           code_quoted: { type: 'string' },
           mitigating_factors_found: { type: 'array', items: { type: 'string' } },
           repo_settings_checked: { type: 'array', items: { type: 'string' } },


### PR DESCRIPTION
# Summary

Finding PR-456673 (repeatability / threshold-grid mismatch) in `skills/code-review-deep/code-review-deep.workflow.js`.

**The defect.** The comment above `SEV_THRESHOLDS` asserted an invariant that the verify prompt actively broke: "the validator scores on the anchor grid 0/25/50/75/100 ... Thresholds MUST land ON those anchors ... Keep every value in {25, 50, 75}." But `buildVerifyPrompt` told the validator the opposite:

> 'Confidence score (CONFIRMs only): output ANY integer 0-100 and interpolate between these anchors — do NOT snap only to'
> 'the round numbers. ...'

So the emitted confidence distribution was continuous while the cut-offs were chosen assuming it was discrete. With `high`, `medium` and `low` all set at 50, every CONFIRMed finding scored 26-49 — precisely the interpolated band the prompt invited — landed in `filtered` instead of `kept`, i.e. real, confirmed findings were silently demoted from the report body into the appendix.

**The fix.** Scoring is now discrete, and enforced in two places rather than merely assumed:

1. `buildVerifyPrompt` now instructs "output EXACTLY one of 0, 25, 50, 75, 100. Do not interpolate; pick the nearest anchor and justify the choice in `confidence_rationale`." The anchor definitions and the trailing "REJECTED = 0. CONFIRMED must score >= 25." rule are unchanged.
2. `VERDICT_SCHEMA` pins `confidence_score` to `enum: [0, 25, 50, 75, 100]`, so an off-grid value fails structured-output validation and the model retries, rather than being accepted and mis-bucketed.

The `SEV_THRESHOLDS` comment was updated to describe what now actually happens — the grid is enforced by both the prompt and the schema.

**Decision and rejected alternative.** The fix makes scoring discrete, matching the stated intent of the `SEV_THRESHOLDS` comment, whose own rationale is "so stochastic re-runs stay deterministic". The alternative considered and rejected was to keep continuous scoring and move the thresholds to the anchor midpoints (13 / 38 / 38 / 38 / 63); that also closes the gap, but leaves the verdict distribution stochastic across re-runs, which is the property this phase is trying to preserve. A reviewer who prefers the continuous model can overrule on that basis.

Note: the opening "Mission: try to DISPROVE" lines of `buildVerifyPrompt` are deliberately untouched here — they are owned by the sibling PR `fix/code-review-deep-verify-burden`.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: the repo has no test harness for workflow scripts; the change was verified with `node --check` and by reading the diff against the thresholds it feeds.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

Behavioural effect on existing reports: findings that previously scored in the 26-49 band and were routed to the appendix will now score 25 or 50 and be bucketed deterministically. Reports run after this change may therefore surface more confirmed findings in the main body — that is the bug being fixed, not a regression.
