### PR TITLE
Anchor sprint-summary effort bands and gate the Jira write

### DIFF
--- a/skills/sprint-summary/SKILL.md
+++ b/skills/sprint-summary/SKILL.md
@@ -8,6 +8,13 @@ allowed-tools: Bash(jira:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(ca
 
 Generate a sprint work summary grouped by repository with items organized into approximately 3-day work blocks.
 
+## Arguments
+
+Parse arguments from the user's invocation:
+
+- No flag (default) — compute estimates for items that have none, use them in the report, and write nothing to Jira. The run is read-only; the user must explicitly opt in to writes.
+- `--write-estimates` — after computing them, save the estimates back to Jira as the original estimate on items that had none (Step 4.3). Without this flag, never call `jira issue edit` or `mcp__atlassian__editJiraIssue`.
+
 ## Run from the target repo's directory (direnv)
 
 The `jira` CLI authenticates with the `JIRA_URL`/`JIRA_EMAIL`/`JIRA_API_TOKEN` that [direnv](https://direnv.net/) loads from the `.envrc` of the **current working directory**. Run it from a directory whose `.envrc` belongs to a different project/account and it authenticates as the wrong account — the command fails, or summarizes the wrong sprint.
@@ -108,30 +115,32 @@ For each item, check if a time estimate already exists in Jira:
 
 1. **If `timeoriginalestimate` is set**: Use it directly. Convert seconds to days (divide by 28800 for 8-hour days). Skip AI estimation for this item.
 
-2. **If no estimate exists**: Read the summary and description and estimate the effort in working days using these heuristics:
+2. **If no estimate exists**: Read the summary and description and pick exactly one of the six emittable values below. These six are the **only** values this skill may produce — never 0.75, never 1.5, never 4, never "5+".
 
-   | Indicator | Estimated Days |
-   | --------- | -------------- |
-   | Trivial fix, typo, config change, simple toggle | 0.25 - 0.5 days |
-   | Small bug fix, minor UI change, small refactor | 0.5 - 1 day |
-   | Medium feature, moderate bug, API endpoint, integration | 1 - 2 days |
-   | Large feature, complex bug, multi-component change | 2 - 3 days |
-   | Very large task, architectural change, major feature | 3 - 5 days |
-   | Epic-sized work, full system redesign | 5+ days |
+   | Estimated Days | Select when the described change is |
+   | -------------- | ----------------------------------- |
+   | 0.25 | a one-line edit, a copy/text change, or a config/flag value change only |
+   | 0.5 | confined to one file, adding no new interface (no new endpoint, screen, table, or public function) |
+   | 1 | a few files inside one module, adding no new interface |
+   | 2 | spread across several files in one module, or adding one endpoint, screen, or job |
+   | 3 | spanning two or more modules, or changing an interface other code already calls |
+   | 5 | crossing a service or repository boundary, or changing a database schema or data contract |
 
-   Consider these factors when estimating:
+   **Tie-break**: when the description fits two rows, take the larger of the two. When the description is too vague to place at all, take 2.
+
+   Consider these factors when choosing **between two adjacent rows** — they never produce a value outside the six above:
    - **Priority/severity**: Higher priority bugs often indicate complexity
    - **Keywords**: "refactor", "migrate", "redesign", "overhaul" suggest larger effort
    - **Scope words**: "all", "every", "entire", "complete" suggest larger scope
    - **Specificity**: Very specific tasks ("change button color") are smaller than vague ones ("improve performance")
 
-3. **Save AI estimates back to Jira**: For items where the estimate was AI-generated, save it to Jira as the original estimate in hours:
+3. **Save estimates back to Jira — only with `--write-estimates`**: By default the computed estimate is used in the report and nothing is written to Jira. When the user passed `--write-estimates`, save each computed estimate as the original estimate in hours:
 
    ```bash
    jira issue edit <ISSUE-KEY> --no-input -o "Original Estimate=<HOURS>h"
    ```
 
-   Convert days to hours (multiply by 8). This ensures subsequent runs use the saved estimate directly.
+   Convert days to hours (multiply by 8). This makes subsequent runs use the saved estimate directly. Without the flag, skip this command entirely — the estimate stays local to the report and is recomputed next run.
 
 ## Step 5: Group Items into ~3-Day Blocks
 
@@ -230,11 +239,23 @@ Use the Jira item status (e.g., "In Code Review", "In Progress", "Done") and des
 
    List overloaded persons first, then OK, then underloaded. Unassigned items go last with no status.
 
+5. After the load table, state on its own line how the computed estimates were handled, counting only the items that had no estimate in Jira:
+
+   ```text
+   Estimates: <N> items estimated, not written to Jira (re-run with --write-estimates to save them).
+   ```
+
+   When `--write-estimates` was passed, say so instead:
+
+   ```text
+   Estimates: <N> items estimated and saved to Jira as Original Estimate.
+   ```
+
 ## Important Rules
 
 - **Exclude stories**: Only include Tasks and Bugs (and any sub-types of these). Never include Stories or Epics.
-- **Effort estimation**: Use existing Jira time estimates when present. Only AI-estimate when no estimate exists, and save the AI estimate back to Jira.
-- **Write scope**: The only modification this skill makes to Jira is saving time estimates on items that have none. Never create, delete, move, or change status of any Jira issues.
+- **Effort estimation**: Use existing Jira time estimates when present. Only estimate when no estimate exists, and emit one of the six values 0.25, 0.5, 1, 2, 3, 5 days — nothing between and nothing above.
+- **Write scope**: The skill is read-only by default. The only modification it can ever make to Jira is saving time estimates on items that have none, and only when the user passed `--write-estimates`. Never create, delete, move, or change status of any Jira issues.
 - **Timeout**: Set 15 second timeout on jira commands. If a command hangs, it may be misconfigured.
 - **Link format**: Always use the server URL from the Jira config file, not a hardcoded URL.
 - **Grouping flexibility**: The ~3-day target is approximate. Groups of 2-4 days are acceptable. Prefer logical grouping (related items together) over exact day counts when items are thematically related.


### PR DESCRIPTION
# Summary

Fixes finding PR-368f82 (high, repeatability/unanchored_rubric) in `skills/sprint-summary/SKILL.md`.

**The defect.** Step 4.2 estimated effort from a rubric whose bands overlapped at every boundary and whose row labels were subjective: `0.25 - 0.5 days` for "Trivial fix, typo, config change, simple toggle", `0.5 - 1 day` for "Small bug fix, minor UI change, small refactor", `1 - 2 days` for "Medium feature, moderate bug, API endpoint, integration", up to `5+ days` for "Epic-sized work, full system redesign". Nothing said which side of a shared boundary wins, and nothing anchored "medium" or "large" to an observable property of the ticket, so the same ticket could score 0.5 on one run and 1.0 on the next. Step 4.3 then ran `jira issue edit <ISSUE-KEY> --no-input -o "Original Estimate=<HOURS>h"` unconditionally — no dry-run default, no confirmation — and Step 4.1 ("If `timeoriginalestimate` is set: Use it directly") trusted that stored value forever after. One run's variance became permanent, and propagated into the Step 5 bin-packing, the group count, the FTE line and every Load % in the Step 7 table.

**The fix, in two parts.**

1. *The rubric now emits a fixed set.* The overlapping-range table is replaced with six discrete values — 0.25, 0.5, 1, 2, 3, 5 days — each selected by a countable property of the change rather than an adjective: a one-line or config-only edit; one file with no new interface; a few files in one module with no new interface; several files or one new endpoint/screen/job; two or more modules or a changed interface other code calls; a service/repo boundary crossing or a schema/data-contract change. An explicit tie-break rule takes the larger band when two rows fit, and takes 2 when the description is too vague to place at all. The existing "Consider these factors" list is kept, but scoped to choosing between two adjacent rows — it can no longer create a value outside the six.

2. *The Jira write is gated.* A new Arguments section adds `--write-estimates`. By default the estimates are computed, used in the report, and nothing is written to Jira; only `--write-estimates` permits the `jira issue edit` call in Step 4.3. Step 7 now prints an `Estimates:` line stating whether the estimates were saved to Jira or only computed, so the reader always knows which mode ran. The "Write scope" Important Rule and the "Effort estimation" rule were updated to match.

**Decision, and the alternative rejected.** This makes `sprint-summary` read-only by default, matching every other tracker skill in the plugin: `verify-resolved-issues` defaults to `--dry-run`, and `weekly-dev-report` and `monday-weekly-report` are read-only. The rejected alternative was to keep the write unconditional and only fix the rubric — that would have left a skill whose stated purpose is to *summarize* silently mutating tickets on every run, and would still have made any residual estimation variance permanent on first contact.

**This is a breaking change** for anyone relying on estimates being saved to Jira automatically. Existing invocations that expect `Original Estimate` to be populated must now pass `--write-estimates`.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [x] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: The change is entirely prose in a skill definition (`SKILL.md`); the repo has no harness for asserting on skill instruction text. Verified with `markdownlint-cli2` (0 issues) and by reading the diff end to end.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The breaking part is narrow and recoverable: the estimate is still computed and still shown in the report, it is simply no longer persisted unless asked for. Anyone who wants the previous behaviour appends `--write-estimates` to the invocation. Nothing that was previously written to Jira is removed or altered.

Only `skills/sprint-summary/SKILL.md` is touched. No other skill, script, or document is changed.
