### PR TITLE
Grant skills the tools their instructions require

### DIFF
--- a/skills/appstore/SKILL.md
+++ b/skills/appstore/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: appstore
 description: Manage App Store Connect apps, builds, or distribution. Use when the user wants to check builds, manage TestFlight beta groups and testers, read or respond to App Store reviews, manage in-app purchases, subscriptions, pricing, list app versions, check app status, manage certificates, provisioning profiles, screenshots, app metadata, or perform any App Store Connect operation.
-allowed-tools: Bash(echo:*), Bash(jq:*), mcp__appstore__*
+allowed-tools: Bash(echo:*), Bash(jq:*), Bash(curl:*), Bash(python3:*), Bash(unzip:*), Bash(xcrun:*), mcp__appstore__*
 ---
 
 # App Store Connect

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-pr
 description: Create, open, submit, or prepare a pull request (PR). Generates the commit message, PR title, and PR body, opens the PR, then returns the repo to its default branch. Use when the user wants to create a PR, open a PR, submit a PR, make a PR, push a PR, send a PR, generate PR content, prepare a pull request, or fill a PR template from code changes.
-allowed-tools: Bash(git:*), Bash(gh:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(open:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Bash(xcodebuild:*), Bash(swift:*), Bash(xcrun:*), Bash(npm:*), Bash(yarn:*), Bash(pnpm:*), Bash(bundle:*), Bash(pytest:*), Bash(go:*), Bash(dotnet:*), Read, Glob
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(open:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Bash(xcodebuild:*), Bash(swift:*), Bash(xcrun:*), Bash(npm:*), Bash(yarn:*), Bash(pnpm:*), Bash(bundle:*), Bash(pytest:*), Bash(go:*), Bash(dotnet:*), Read, Glob, Skill, mcp__github__*
 ---
 
 # Create Pull Request

--- a/skills/review-architecture/SKILL.md
+++ b/skills/review-architecture/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-architecture
 description: Review, create, update, check, write, document, or audit architecture documentation (docs/architecture.md). Use when the user wants to review the architecture, check architecture docs, write architecture docs, document the architecture, or update architecture documentation to match organizational standards with accurate technical content.
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, WebSearch, mcp__github__get_file_contents, mcp__fetch__fetch, mcp__context7__resolve-library-id, mcp__context7__query-docs
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, TodoWrite, WebSearch, Skill, mcp__github__get_file_contents, mcp__fetch__fetch, mcp__context7__resolve-library-id, mcp__context7__query-docs
 ---
 
 # Review Architecture Documentation
@@ -10,7 +10,7 @@ Review or create `docs/architecture.md` to match organizational standards. Works
 
 ## Phase Tracking
 
-Use `TaskCreate` to track each phase below. Mark `in_progress` on entry, `completed` when results are recorded. Do NOT include the task list in the final output.
+Use `TodoWrite` to track each phase below. Mark `in_progress` on entry, `completed` when results are recorded. Do NOT include the task list in the final output.
 
 **Required phases:**
 

--- a/skills/review-copy/SKILL.md
+++ b/skills/review-copy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-copy
 description: Review, audit, or improve user-facing copy — UI microcopy (error messages, empty states, confirmation dialogs, loading states, buttons/CTAs), form labels and help text, voice/tone consistency, i18n readiness, and marketing copy. Use when the user wants a copy review, to check or fix UI text, audit microcopy, improve error messages or empty states, tighten button/CTA wording, review form help text, check inclusive/plain language, find hardcoded strings, or review landing-page/marketing copy. Audits a codebase (optionally a path or the current diff) and writes docs/copy-review.md.
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, WebSearch, AskUserQuestion, Skill, mcp__github__get_file_contents
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, TodoWrite, WebSearch, AskUserQuestion, Skill, mcp__github__get_file_contents
 ---
 
 # Review Copy
@@ -12,7 +12,7 @@ This is primarily a **review** skill (find issues, propose fixes, apply on appro
 
 ## Phase Tracking
 
-Use `TaskCreate` to track each phase. Mark `in_progress` on entry, `completed` when recorded. Do NOT include the task list in the final output.
+Use `TodoWrite` to track each phase. Mark `in_progress` on entry, `completed` when recorded. Do NOT include the task list in the final output.
 
 **Required phases:**
 

--- a/skills/review-design/SKILL.md
+++ b/skills/review-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-design
 description: Review, compare, audit, or check UI code against Figma designs. Use when the user wants to compare code to a Figma design, check design implementation, audit UI fidelity, verify design compliance, or review design-to-code accuracy. Supports Android (Jetpack Compose, XML layouts), iOS (SwiftUI, UIKit), and web (HTML/CSS, React, Vue, Angular) platforms.
-allowed-tools: Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Glob, Grep, mcp__figma__get_design_context, mcp__figma__get_screenshot, mcp__figma__search_design_system, mcp__figma__get_metadata, mcp__figma__get_variable_defs, mcp__figma__get_code_connect_map, mcp__figma__get_code_connect_suggestions
+allowed-tools: Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Glob, Grep, Skill, mcp__figma__get_design_context, mcp__figma__get_screenshot, mcp__figma__search_design_system, mcp__figma__get_metadata, mcp__figma__get_variable_defs, mcp__figma__get_code_connect_map, mcp__figma__get_code_connect_suggestions
 ---
 
 # Review Design Implementation

--- a/skills/review-readme/SKILL.md
+++ b/skills/review-readme/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-readme
 description: Review, create, update, check, fix, improve, write, or audit README.md. Use when the user wants to review the README, check the README, fix the README, write a README, improve the README, or update the README to match organizational standards with accurate project-specific content.
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, WebSearch, mcp__github__get_file_contents, mcp__fetch__fetch, mcp__context7__resolve-library-id, mcp__context7__query-docs
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, WebSearch, Skill, mcp__github__get_file_contents, mcp__fetch__fetch, mcp__context7__resolve-library-id, mcp__context7__query-docs
 ---
 
 # Review README.md

--- a/skills/review-seo/SKILL.md
+++ b/skills/review-seo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-seo
 description: Review, audit, or check SEO, GEO (AI answer-engine / generative-engine optimization), and front-end web quality (performance, Core Web Vitals, accessibility). Use when the user wants an SEO audit, technical SEO check, GEO/AEO audit, AI-search optimization, llms.txt review, structured-data/schema check, meta-tag/Open-Graph audit, sitemap or robots.txt review, crawlability analysis, a Lighthouse or web-quality audit, a performance or Core Web Vitals (LCP/INP/CLS) review, or an accessibility (WCAG) audit. Audits a codebase and/or a live site URL (usually production) and writes docs/seo-audit.md.
-allowed-tools: Bash(curl:*), Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, WebSearch, WebFetch, AskUserQuestion, Skill, mcp__fetch__fetch, mcp__github__get_file_contents, mcp__chrome-devtools__*
+allowed-tools: Bash(curl:*), Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, TodoWrite, WebSearch, WebFetch, AskUserQuestion, Skill, mcp__fetch__fetch, mcp__github__get_file_contents, mcp__chrome-devtools__*
 ---
 
 # Review SEO & GEO
@@ -12,7 +12,7 @@ Works against a **codebase**, a **live URL** (usually production), or **both** â
 
 ## Phase Tracking
 
-Use `TaskCreate` to track each phase. Mark `in_progress` on entry, `completed` when results are recorded. Do NOT include the task list in the final output.
+Use `TodoWrite` to track each phase. Mark `in_progress` on entry, `completed` when results are recorded. Do NOT include the task list in the final output.
 
 **Required phases:**
 

--- a/skills/review-user-guide/SKILL.md
+++ b/skills/review-user-guide/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-user-guide
 description: Review, create, update, check, write, or audit the user guide (docs/user-guide.md). Use when the user wants to write a user guide, write user docs, create user documentation, review the user guide, check the user guide, update user documentation, or document the product for end users.
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, WebSearch, mcp__github__get_file_contents, mcp__fetch__fetch, mcp__context7__resolve-library-id, mcp__context7__query-docs
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, TodoWrite, WebSearch, Skill, mcp__github__get_file_contents, mcp__fetch__fetch, mcp__context7__resolve-library-id, mcp__context7__query-docs
 ---
 
 # Review User Guide Documentation
@@ -10,7 +10,7 @@ Review or create `docs/user-guide.md` from an end-user perspective. Works for al
 
 ## Phase Tracking
 
-Use `TaskCreate` to track progress: one task per phase below. Mark `in_progress` when starting, `completed` when results are recorded. Do NOT include the task list in the final output — it's internal tracking.
+Use `TodoWrite` to track progress: one task per phase below. Mark `in_progress` when starting, `completed` when results are recorded. Do NOT include the task list in the final output — it's internal tracking.
 
 **Required phases:**
 


### PR DESCRIPTION
# Summary

Fixes finding **PR-ba308b** (high, corpus/wiring): eight skills instruct Claude to use a tool that is
absent from their own `allowed-tools` frontmatter, so the instruction silently cannot execute at
runtime. Each fix makes the frontmatter match what the skill body already asks for — no body
behaviour was changed apart from the tool name noted below.

## The defect, file by file

**Phase trackers — missing todo tool.** Four skills open their `## Phase Tracking` section by
instructing the model to track each phase, e.g. `skills/review-architecture/SKILL.md`:

> Use `TaskCreate` to track each phase below. Mark `in_progress` on entry, `completed` when results
> are recorded.

`TaskCreate` is granted by none of them, and it is not the mechanism the rest of this plugin uses.
Affected: `skills/review-architecture/SKILL.md`, `skills/review-copy/SKILL.md`,
`skills/review-seo/SKILL.md`, `skills/review-user-guide/SKILL.md`.

**Skill invocation — missing `Skill`.** Four skills tell the model to run another skill but never
declare `Skill`:

- `skills/review-architecture/SKILL.md` — "After writing/updating, run `/co-dev:run-linters` and fix any errors."
- `skills/review-design/SKILL.md` — "**Run linters after changes** — Always run `/co-dev:run-linters` after modifying code"
- `skills/review-readme/SKILL.md` — "**Run linters after changes** - Always run `/co-dev:run-linters` after modifying README.md"
- `skills/review-user-guide/SKILL.md` — "After writing/updating the guide, run `/co-dev:run-linters` and fix any errors before reporting completion."

(`review-copy` and `review-seo` already declared `Skill`; they were left alone.)

**`skills/create-pr/SKILL.md`.** Step 6 states "Prefer `mcp__github__create_pull_request` when the
GitHub MCP server is available", and the Important Rules delegate linting to the run-linters skill —
but `allowed-tools` ended at `Read, Glob`. Appended `Skill, mcp__github__*`.

**`skills/appstore/SKILL.md`.** The entire "Xcode Cloud build logs / failures (MCP gap)" fallback is
shell: it mints a JWT with `python3`, calls the App Store Connect API with `curl`, then `unzip`s the
artifact and reads it with `xcrun xcresulttool`. `allowed-tools` was only
`Bash(echo:*), Bash(jq:*), mcp__appstore__*`, so none of it could run. This is the highest-impact
entry of the eight: it is the only documented path to Xcode Cloud failure details, and both
`create-pr` Step 7 and `work-issue` Step 9 route users to it. Added
`Bash(curl:*), Bash(python3:*), Bash(unzip:*), Bash(xcrun:*)`.

## Decision: TaskCreate -> TodoWrite

Rather than granting `TaskCreate`, the four phase-tracker bodies now say `TodoWrite`, and `TodoWrite`
was added to their `allowed-tools`. **Rejected alternative:** adding `TaskCreate` to the four
`allowed-tools` lines and leaving the bodies as-is. That would have introduced a second, parallel
progress-tracking mechanism into a plugin where `code-review-deep`, `migrate-code`, and `work-issue`
all already declare and use `TodoWrite` for exactly this purpose. Converging on the existing
mechanism keeps one way to do it.

Existing entry order and the comma-space single-line convention were preserved in every list; nothing
was reordered or removed.

## Suggested follow-up (not in this PR)

Add a CI check that every backticked tool name and every `/co-dev:` skill reference appearing in a
`SKILL.md` body resolves against that same file's `allowed-tools` (with `Skill` required for any
`/co-dev:` reference, and `Bash(<cmd>:*)` required for commands used in fenced shell blocks). This
class of defect is mechanically detectable and will otherwise keep recurring as skill bodies grow.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: This repo has no test harness for skill frontmatter; the change is declarative YAML metadata. Verified with `markdownlint-cli2` (0 issues across all 37 markdown files) and by confirming no `TaskCreate` reference remains anywhere under `skills/`. The suggested CI check above is the durable form of this test.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

Broadening `allowed-tools` widens what these skills may invoke, so the additions were kept minimal
and evidence-driven: every entry added is justified by a specific instruction already present in that
same file's body. In particular `appstore` gained `Bash(curl:*)`, `Bash(python3:*)`, `Bash(unzip:*)`,
and `Bash(xcrun:*)` — exactly the four binaries its documented fallback invokes, and nothing wider.
