### PR TITLE
Define run-linters behaviour when the linters wrapper is absent

### DIFF
--- a/skills/run-linters/SKILL.md
+++ b/skills/run-linters/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-linters
 description: Run linters, lint the code, check code style, or fix linting issues. Use when the user wants to lint, run linters, check code quality, verify code style, fix linting errors, or run code checks after completing code modifications.
-allowed-tools: Bash(linters:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Edit
+allowed-tools: Bash(linters:*), Bash(awk:*), Bash(basename:*), Bash(bundle:*), Bash(cargo:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(diff:*), Bash(dirname:*), Bash(echo:*), Bash(find:*), Bash(go:*), Bash(golangci-lint:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(make:*), Bash(mkdir:*), Bash(npm:*), Bash(npx:*), Bash(pnpm:*), Bash(python3:*), Bash(rake:*), Bash(rubocop:*), Bash(ruff:*), Bash(sed:*), Bash(shellcheck:*), Bash(sort:*), Bash(tail:*), Bash(tee:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Bash(yamllint:*), Bash(yarn:*), Read, Edit
 ---
 
 # Run Linters
@@ -13,6 +13,33 @@ Execute linters after code changes are complete to ensure code quality and consi
 - After completing a set of code changes (not after each small edit)
 - Before creating a commit or PR
 - When asked to verify code quality
+
+## Step 0: Check for the linters wrapper
+
+The `linters` wrapper is the preferred path, but it is not installed everywhere. Check for it first:
+
+```bash
+which linters
+```
+
+**If `linters` is found:** continue to Step 1 unchanged.
+
+**If `linters` is NOT found:** tell the user plainly that the `linters` wrapper is not installed on this machine and that you are falling back to the repository's own linters. Then detect which linters the repository configures and run them directly:
+
+| Config file present | Linter to run |
+| --- | --- |
+| `.eslintrc*`, `eslint.config.*` | `npx eslint .` |
+| `.rubocop.yml` | `bundle exec rubocop` (or `rubocop`) |
+| `ruff.toml`, `.ruff.toml`, `pyproject.toml` (with `tool.ruff`) | `ruff check .` |
+| `.golangci.yml`, `.golangci.yaml` | `golangci-lint run` |
+| `Cargo.toml` | `cargo clippy` |
+| `.markdownlint*` | `npx markdownlint-cli2 .` |
+| `.yamllint*` | `yamllint .` |
+| `*.sh` files | `shellcheck` on the shell scripts |
+
+Prefer the project's own runner whenever one exists — an `npm run lint` script in `package.json`, a `rake lint` task, or a `make lint` target that already wraps the linter — over invoking the binary directly. Use the package manager the repository already uses (`npm`, `yarn`, or `pnpm`).
+
+If neither the `linters` wrapper nor any recognised linter config is found, stop and tell the user exactly which config files you searched for. Do NOT claim the code is lint-clean.
 
 ## Step 1: Run Linters
 
@@ -42,6 +69,7 @@ Repeat until all issues are resolved.
 
 - Do NOT run after every small change - wait until a logical set of changes is complete
 - Fix all issues before reporting completion
+- **NEVER report lint success without a linter having actually run and produced output** - a missing command, a failed invocation, or a run you skipped is not a pass
 - **NEVER modify linter configuration files** to suppress or ignore issues
 - **NEVER add inline disable comments** (e.g., `// eslint-disable`, `# noqa`, `// nolint`) to bypass issues
 - Always fix the actual code, not the linter rules


### PR DESCRIPTION
<!-- Distributed by repos.sh from Cloud-Officer/aws:github/PULL_REQUEST_TEMPLATE-generic.md - edit it there, local changes are overwritten. -->

# Summary

Addresses finding **PR-8de88d** (high, gaps/unhandled failure) from the prompt review.

**The defect:** `skills/run-linters/SKILL.md` was built entirely around a bespoke `linters` wrapper command with no branch for that command not existing. Step 1 said "Execute the `linters` command which auto-detects active linters in the current repository", Step 3 said "Re-run `linters` to verify the fix", and `allowed-tools` granted `Bash(linters:*)` and no other linter runner. There was no detection step, no fallback, and no failure branch. On a machine or repo without the wrapper the command exits "command not found", and the skill's only defined outcomes were "If no issues: Report success and proceed" and "If issues found: Continue to Step 3" — so the model had to improvise: either report success on a non-zero exit, or reach for a tool it was not permitted to run. Five skills gate on this one: `create-pr` (Important Rules), `write-tests` (co-dev integration), `migrate-code` (Step 4.5, unconditional), `review-copy` (Phase 12) and `review-seo` (Phase 10).

**What the fix does:**

1. Adds a new **Step 0: Check for the linters wrapper** before the existing Step 1. It runs `which linters` and defines both branches explicitly. If the wrapper is present, the skill continues to Step 1 unchanged. If it is absent, the skill says so plainly to the user and falls back to the repository's own configured linters, using a detection table mapping config file to command (eslint, rubocop, ruff, golangci-lint, clippy, markdownlint-cli2, yamllint, shellcheck). The fallback prefers the project's own runner (an `npm run lint` script, a `rake lint` task, a `make lint` target) over invoking a binary directly. If neither the wrapper nor any recognised linter config is found, the skill stops and reports which configs it searched for instead of claiming success.
2. Adds a rule to **Important Rules**: never report lint success without a linter having actually run and produced output. This is the core of the finding — a missing command, a failed invocation, or a skipped run is not a pass.
3. Extends `allowed-tools` with the runners the fallback is now permitted to invoke (`npm`, `npx`, `yarn`, `pnpm`, `bundle`, `rubocop`, `ruff`, `python3`, `golangci-lint`, `go`, `cargo`, `shellcheck`, `yamllint`, `rake`, `make`), inserted alphabetically into the existing single-line list. `Bash(which:*)` was already granted and Step 0 now actually uses it.

**Decision taken:** the `linters` wrapper is treated as the *preferred* path with a real per-language fallback, not as a hard prerequisite — so the skill keeps working on machines and repos that do not have the wrapper installed. **The rejected alternative** was a loud stop plus a documented install step whenever the wrapper is missing; that was not chosen because five downstream skills invoke `run-linters` unconditionally and would all become blocked on any machine without the wrapper. A reviewer who prefers the hard-prerequisite behaviour can overrule this here.

Steps 1-3, the Forbidden Files list, the Forbidden Patterns list and the Shell Script Linting Rules are unchanged.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this is a prompt/skill Markdown document with no executable code path to assert against; it was verified with `markdownlint-cli2` (0 issues) and by reading the rendered instructions end to end.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The `allowed-tools` widening is worth a careful look: the fallback needs permission to invoke the language-native linters, which means `run-linters` can now run `npm`, `bundle`, `go`, `cargo`, `rake` and `make`. These are the runners the linters themselves are usually wrapped in, but they are broader grants than `Bash(linters:*)` alone. If the project would rather keep the permission surface narrow, the alternative is to grant only the linter binaries (`rubocop`, `ruff`, `golangci-lint`, `shellcheck`, `yamllint`, `npx`) and drop the "prefer the project's own runner" guidance.
