### PR TITLE
Name one source of truth for resolved-issue verification

### DIFF
--- a/skills/verify-resolved-issues/SKILL.md
+++ b/skills/verify-resolved-issues/SKILL.md
@@ -91,7 +91,7 @@ The expensive part of this skill — reading each issue's claims, reading its li
 **Division of labour:**
 
 - **The skill (this file) does:** tracker detection (Step 1), candidate discovery (Step 2-G / 2-J + 3-J), resolver identification (Step 3-G / 4-J), and finding the linked merged PRs (Step 5-J). Then it **confirms once** before any write (`--apply`) and performs the actual writes (Step 5-G / 7-J).
-- **The workflow does:** the per-issue verification (Step 4-G / 6-J) and comment drafting, returning a structured verdict per issue. The verification checklist, the three-way outcome rules, the `SKIP_NEEDS_MANUAL` guidance, the comment templates, and the language rule all live in `${CLAUDE_PLUGIN_ROOT}/skills/verify-resolved-issues/verify-resolved-issues.workflow.js`. To tune *how a fix is judged or how a comment reads*, edit that file — not the steps below.
+- **The workflow does:** the per-issue verification (Step 4-G / 6-J) and comment drafting, returning a structured verdict per issue. The verification checklist, the four-way outcome rules, the `SKIP_NEEDS_MANUAL` guidance, the comment templates, and the language rule all live in `${CLAUDE_PLUGIN_ROOT}/skills/verify-resolved-issues/verify-resolved-issues.workflow.js`. To tune *how a fix is judged or how a comment reads*, edit that file — not the steps below.
 
 **Before launching**, `cd` into the target repo (its own Bash call) so the workflow's agents inherit the right working directory and direnv token — their `gh`/`git`/test-runner calls depend on it. Then invoke:
 
@@ -173,7 +173,7 @@ For each candidate:
 
 ### Step 4-G: Verify in current codebase
 
-> **Delegated to the workflow.** Don't run this per-issue loop inline — pass all candidates discovered in Steps 2-G / 3-G to `verify-resolved-issues.workflow.js` (see "Parallel verification via workflow" above) and use its returned verdicts. The checklist below documents what each workflow agent does, and stays the source of truth for that logic.
+> **Delegated to the workflow.** Don't run this per-issue loop inline — pass all candidates discovered in Steps 2-G / 3-G to `verify-resolved-issues.workflow.js` (see "Parallel verification via workflow" above) and use its returned verdicts. The checklist below is reference only, kept so a reader can see what each workflow agent does. The workflow file is authoritative — edits here change nothing at runtime.
 
 For each candidate, decide whether the merged PR's intent matches what the issue described AND whether the changes are still present on the default branch.
 
@@ -185,7 +185,7 @@ For each candidate, decide whether the merged PR's intent matches what the issue
    - If the issue was a regression bug: search for the old pattern that was supposed to be removed; if it's still there, the fix didn't take.
 4. **If a linter or test runner is configured**, run it against the affected paths only — don't run the whole suite unless cheap. Look for regressions specifically related to the fix.
 
-Decide one of three outcomes: **VERIFIED** (fix matches issue + present in codebase), **NOT_VERIFIED** (missing, partial, reverted, or never matched the issue's intent), or **SKIP_NEEDS_MANUAL** (the issue's correctness cannot be determined from code alone — it requires a human tester to confirm).
+Decide one of four outcomes: **VERIFIED** (fix matches issue + present in codebase), **NOT_VERIFIED** (missing, partial, reverted, or never matched the issue's intent), **SKIP_NEEDS_MANUAL** (the issue's correctness cannot be determined from code alone — it requires a human tester to confirm), or **SKIP_INSUFFICIENT** (not enough signal to judge: no merged PR actually linked, ambiguous resolver, the referenced code or symbol entirely gone with no traceable history — report-only, like `SKIP_NEEDS_MANUAL`).
 
 `SKIP_NEEDS_MANUAL` covers cases where reading code can't yield a confident verdict: visual / pixel / layout bugs, animation timing, cross-browser or device-specific rendering, end-to-end UX flows behind auth or third-party services, performance perception, audio/video, accessibility behavior with assistive tech, anything depending on a live external integration or staging environment. **When this is the outcome, do nothing** — no comment, no transition, no reassignment. Just record it as skipped in the report so a human can pick it up. A drive-by audit comment on a UX bug helps no one and clutters the ticket.
 
@@ -319,7 +319,7 @@ If dev-info is empty, fall back to a GitHub search for the issue key in PR title
 
 > **Delegated to the workflow.** Like Step 4-G, pass all candidates (with their resolver and linked-PR data from Steps 4-J / 5-J) to `verify-resolved-issues.workflow.js` and act on its verdicts. The procedure below is what each workflow agent runs.
 
-Same procedure as **Step 4-G**, including the three-way outcome: **VERIFIED**, **NOT_VERIFIED**, or **SKIP_NEEDS_MANUAL**. Read the issue description and acceptance criteria, read the touched files in the current working tree, confirm the described behavior is present, run tests/linters narrowly if useful. If the ticket's correctness cannot be determined from code alone (visual/UX bugs, third-party integrations, device-specific behavior — see Step 4-G), mark **SKIP_NEEDS_MANUAL** and **do nothing on the ticket** — no comment, no transition, no reassignment. Skipped tickets only show up in the report.
+Same procedure as **Step 4-G**, including the four-way outcome: **VERIFIED**, **NOT_VERIFIED**, **SKIP_NEEDS_MANUAL**, or **SKIP_INSUFFICIENT** (not enough signal to judge — no merged PR actually linked, ambiguous resolver, the referenced code or symbol entirely gone with no traceable history; report-only, like `SKIP_NEEDS_MANUAL`). Read the issue description and acceptance criteria, read the touched files in the current working tree, confirm the described behavior is present, run tests/linters narrowly if useful. If the ticket's correctness cannot be determined from code alone (visual/UX bugs, third-party integrations, device-specific behavior — see Step 4-G), mark **SKIP_NEEDS_MANUAL** and **do nothing on the ticket** — no comment, no transition, no reassignment. Skipped tickets only show up in the report.
 
 The Jira description format is ADF (Atlassian Document Format) — when fetched via MCP it's typically rendered to text already; via REST you may need `?expand=renderedFields` and read `renderedFields.description` (HTML) or walk the `description` ADF tree. Acceptance criteria often live in a custom field — try `customfield_10100` (Atlassian default) and grep the issue's `fields` for keys whose name contains `Acceptance`.
 


### PR DESCRIPTION
# Summary

Finding PR-3310c1 (medium, corpus/authority): `skills/verify-resolved-issues/SKILL.md` named two different files as the source of truth for the same verification logic, and they had already drifted.

The "Division of labour" section says the verification checklist, outcome rules, comment templates, and language rule "all live in `${CLAUDE_PLUGIN_ROOT}/skills/verify-resolved-issues/verify-resolved-issues.workflow.js`. To tune *how a fix is judged or how a comment reads*, edit that file — not the steps below." But the Step 4-G blockquote contradicted it: "The checklist below documents what each workflow agent does, and stays the source of truth for that logic." Both cannot hold — the workflow file is what actually runs.

The drift was already real. SKILL.md said "Decide one of three outcomes" (Step 4-G) and "including the three-way outcome" (Step 6-J), listing VERIFIED / NOT_VERIFIED / SKIP_NEEDS_MANUAL, while `verify-resolved-issues.workflow.js` defines four in its `VERIFY_RULES` and pins all four in `RESULT_SCHEMA` — the fourth being `SKIP_INSUFFICIENT`. The skill's own dry-run output template already renders a "Skipped — insufficient signal" section, so only the Step 4-G / 6-J prose was stale.

This change, in `SKILL.md` only:

- Drops the second source-of-truth claim in the Step 4-G blockquote and marks that checklist explicitly non-normative ("reference only ... The workflow file is authoritative — edits here change nothing at runtime"), keeping the delegation instruction intact.
- Corrects the outcome count in Step 4-G and Step 6-J from three to four, adding `SKIP_INSUFFICIENT` described as the workflow file describes it: not enough signal to judge (no merged PR actually linked, ambiguous resolver, the referenced code or symbol entirely gone with no traceable history), report-only like `SKIP_NEEDS_MANUAL`.
- Updates the "Division of labour" bullet from "the three-way outcome rules" to "the four-way outcome rules".

`verify-resolved-issues.workflow.js` is unchanged — it is the authority and is already correct. The sentence "The per-flow steps below remain the source of truth for **discovery and the writes**" is also kept: discovery and the writes really do live in the skill. The point is that each concern has exactly one owner, not that the skill owns nothing.

Observable symptom removed: an author edits the Step 4-G checklist to change how a fix is judged and nothing changes at runtime, and a reader following the skill would only ever produce three of the four outcomes the workflow's result schema accepts.

Note: `skills/verify-resolved-issues/SKILL.md` is also touched by the sibling branch `fix/verify-resolved-issues-description`, which owns only the frontmatter `description:` line. This PR does not touch that line.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Prose-only change to a skill definition; verified with `markdownlint-cli2` (0 issues) and by cross-checking the outcome list against `VERIFY_RULES` and `RESULT_SCHEMA` in `verify-resolved-issues.workflow.js`.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

No behavior change: the workflow file already implemented four outcomes. Only the skill's prose is corrected so the two files agree and each concern has exactly one owner.
