### PR TITLE
Make the create-issue GitHub path prefer MCP like its Jira path

### DIFF
--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -65,26 +65,35 @@ This skill uses MCP tools when available and falls back gracefully if they are u
 
 ## GitHub Issues
 
-If GitHub issues are enabled, use `gh issue create`.
+If GitHub issues are enabled, create a GitHub issue. **Prefer `mcp__github__create_issue`** when available, fall back to `gh issue create` CLI.
 
 ### Step 2a: Write issue body to `issue-body.md`
 
 Use the appropriate template based on issue type (see Templates section below).
 
-**Note:** This file will be deleted after the command runs.
+**Note:** This file is deleted in Step 2c.
 
-### Step 2b: Run gh command
+### Step 2b: Create the issue
+
+With the MCP tool, pass the same values the CLI flags carry: the title, the body (the contents of `issue-body.md`), the labels, and the assignee if the user specified one.
+
+With the CLI:
 
 ```bash
-gh issue create \
-  --title "<SUMMARY>" \
-  --body-file issue-body.md \
-  --label "<LABEL>" && rm issue-body.md
+gh issue create --title "<SUMMARY>" --body-file issue-body.md --label "<LABEL>"
 ```
 
 Add `--assignee "<username>"` if user specified an assignee.
 
 **Note:** No repo name prefix needed - GitHub issues are already scoped to the repository.
+
+### Step 2c: Delete the temp file
+
+Whichever path you took, remove the temp file once the issue exists:
+
+```bash
+rm issue-body.md
+```
 
 ---
 
@@ -292,7 +301,7 @@ Detailed explanation of what should have happened.
 ## Important Rules
 
 - **GitHub Issues:**
-  - Use `gh issue create` with `--body-file`
+  - Prefer `mcp__github__create_issue`; with the CLI fallback, use `gh issue create` with `--body-file`
   - No repo name prefix needed (issues are scoped to repo)
   - Labels are simple strings (e.g., `bug`, `enhancement`, `documentation`)
 - **Jira Issues:**


### PR DESCRIPTION
# Summary

Finding PR-e70c63: `skills/create-issue/SKILL.md` contradicted itself about which GitHub path to take. The "MCP Tools with Fallbacks" table lists `mcp__github__create_issue` as preferred with `gh issue create` as the fallback, and the Jira section spells that rule out in prose, but the GitHub section said, with no hedge, "If GitHub issues are enabled, use `gh issue create`." — and its Step 2b gave only the CLI form.

Because the two paths were described differently, results varied run to run. Temp-file cleanup rode on `&& rm issue-body.md` at the end of the CLI command line, so on runs that took the MCP path the cleanup never ran and `issue-body.md` was left behind in the user's repo, contradicting the Important Rule "Delete the temp file (`issue-body.md`) after creating the issue". The label and assignee arguments were also only documented in CLI flag shape, so identical requests could produce differently structured issues.

This change:

- Rewrites the GitHub section opener to mirror the Jira one: **Prefer `mcp__github__create_issue`** when available, fall back to `gh issue create` CLI. The two sections now read as siblings.
- Renames Step 2b to "Create the issue" and notes what the MCP path needs that the CLI supplies via flags (title, body from `issue-body.md`, labels, assignee), so a reader on either path passes the same values.
- Pulls temp-file deletion out of the `&&` chain into an explicit Step 2c that runs whichever path was taken, and keeps the `gh issue create` example as a single-line command.
- Updates the GitHub bullet under Important Rules so it no longer asserts the CLI as the only path.

Observable symptom removed: `issue-body.md` is no longer orphaned in the repo after an MCP-path run, and label/assignee handling is specified identically for both paths.

The Jira section, the templates, and the Priority Mapping table are untouched. No sibling PR touches this file.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: This is a prose change to a skill definition; the repo has no test harness for SKILL.md content. Verified with `markdownlint-cli2` (0 issues) and by reading the diff end to end.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

None.
