### PR TITLE
Replace the placeholder cycle-time command with a runnable one

### DIFF
--- a/skills/weekly-dev-report/SKILL.md
+++ b/skills/weekly-dev-report/SKILL.md
@@ -241,22 +241,10 @@ Carry the resolved `member_role` for every member into Steps 6 (rating + deliver
 For each ticket a member transitioned **into** `Code Review` or `in QA` during the weekly window, compute the most recent prior `In Progress` start time and take the delta:
 
 ```bash
-curl -s -u "$JIRA_EMAIL:$JIRA_API_TOKEN" "$JIRA_URL/rest/api/3/issue/<KEY>?expand=changelog&fields=summary" \
-  | jq '{
-      key: .key,
-      summary: .fields.summary,
-      ip_to_cr_seconds: (
-        (.changelog.histories
-          | map({when: .created, items: .items})
-          | map(.items[] |= ({when: .when} + .))
-          | .[].items[]?
-          | select(.field=="status")) as $h
-        | null  # placeholder — see implementation note below
-      )
-    }'
+curl -s -u "$JIRA_EMAIL:$JIRA_API_TOKEN" "$JIRA_URL/rest/api/3/issue/<KEY>?expand=changelog&fields=summary" | jq '{key, summary: .fields.summary, events: [.changelog.histories[] | {when: .created, items: [.items[] | select(.field=="status") | {from: .fromString, to: .toString}]} | select(.items | length > 0)] | sort_by(.when)}'
 ```
 
-Implementation note: the cleanest way is to walk `.changelog.histories | sort_by(.created)` and remember `last_in_progress_at`. When you hit a status change `to == "Code Review"` (or `to == "in QA"` if no Code Review step happened in between), record `delta = parsed(history.created) - last_in_progress_at`. If multiple In-Progress→Code-Review cycles happened on the same ticket, take the **last full cycle that ended within the weekly window**. Skip tickets whose cycle started before the previous sprint's start date (treat as no signal).
+Implementation note: walk `events` in order and remember the timestamp of the last transition whose `to` is `In Progress`. On the first following transition whose `to` is `Code Review` (or `in QA`, when Code Review was skipped), record `delta = parsed(event.when) - last_in_progress_at`. If multiple In-Progress→Code-Review cycles happened on the same ticket, take the **last full cycle that ended within the weekly window**. Skip tickets whose cycle started before the previous sprint's start date (treat as no signal).
 
 Aggregate per member:
 


### PR DESCRIPTION
# Summary

Finding PR-c4254f (medium, gaps/author-left-placeholder).

In `skills/weekly-dev-report/SKILL.md`, Step 3's "Cycle time per ticket (In Progress → Code Review)" subsection presented a complete-looking `curl | jq` command that could not produce the value it claimed to. The jq body ended, inside the pipeline, with:

```text
        | null  # placeholder — see implementation note below
```

so the block always emitted `ip_to_cr_seconds: null`. The prose that followed described the real changelog walk in words but supplied no command. That value is load-bearing: `cycle_avg_hours` fills the "Avg cycle (IP→CR)" column of the team-at-a-glance table in Step 7 and feeds per-member why-lines. Following the code block yielded "—" for every member; following the prose meant reimplementing the changelog walk from scratch, differently on each run.

This change deletes the placeholder and leaves exactly one runnable form:

- The command now fetches the changelog and shapes it for the walk — a single-line `curl | jq` that emits `key`, `summary`, and a chronologically sorted `events` array of status transitions (`when`, plus `items[]` of `{from, to}`), dropping histories with no status change.
- The implementation note now describes what to do with `events` — walk it in order, remember the timestamp of the last transition whose `to` is `In Progress`, and on the first following transition whose `to` is `Code Review` (or `in QA`, when Code Review was skipped) record the delta. The existing rules are kept unchanged: take the last full cycle that ended inside the weekly window, and skip tickets whose cycle started before the previous sprint's start date.
- The aggregation lines just below (`cycle_seconds[]`, `cycle_avg_hours`) still read correctly against the new command and are untouched.

Observable symptom removed: the report no longer renders "—" for every member's cycle time, and two runs of the skill now compute it the same way.

Note: `skills/weekly-dev-report/SKILL.md` is also touched by the branch `fix/report-skill-routing-triggers`, which owns only the frontmatter `description:` line. This change does not go near it — no other section of the file is modified.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: the repo has no test harness for skill markdown; the new jq program was run against a sample Jira changelog payload and `markdownlint-cli2` reports 0 issues.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The jq program was exercised against a synthetic `?expand=changelog` response containing an out-of-order history, a non-status item, and a mixed history carrying both a `summary` and a `status` item. It returned the two status transitions in chronological order and dropped the assignee-only history, confirming the shape the implementation note walks.
