### PR TITLE
Disclose the migrate-code compile, test and verify caps

### DIFF
--- a/skills/migrate-code/SKILL.md
+++ b/skills/migrate-code/SKILL.md
@@ -164,6 +164,7 @@ Operate on the workflow's return value. **Pre-report verification:** confirm the
 - **Lint & coverage backfill (Step 4.5)** — the `run-linters` outcome (clean / fixed / remaining), whether the suite was re-run after autofixes, and, if `write-tests` ran, the coverage numbers and its pass marker.
 - **Blocked & needs-human files** — list them with reasons; these need the user's attention.
 - **Behavioral mismatches** — every `verify` item with `verdict: "mismatch"`, quoting the source-vs-port evidence, sorted by severity. These are the highest-priority follow-ups.
+- **Verification coverage** — state how many ported files were adversarially verified out of how many were ported, and name what the `capped` counts deferred: unverified files (selected by TODO marker count, so a clean-looking file can be skipped entirely), plus any error groups or failing tests the per-round caps dropped. Unverified is not verified — never let the mismatch list read as a full sweep.
 - **Outstanding TODO(migrate) markers** — remind the user to grep for them: `grep -rn "TODO(migrate)" <scope>`.
 - **Rule gaps** — the deduped `rule_gaps`, framed as rulebook amendments to apply before a re-run.
 

--- a/skills/migrate-code/migrate-code.workflow.js
+++ b/skills/migrate-code/migrate-code.workflow.js
@@ -432,6 +432,7 @@ log('Translated ' + portedOk.length + '/' + files.length + '  ·  ' + blocked.le
 // clean or the round budget is spent.
 phase('Compile')
 const compileRuleGaps = []
+let droppedErrorGroups = 0
 let build = { ran: false, clean: false, summary: 'no build command provided' }
 
 if (!buildCmd) {
@@ -453,8 +454,13 @@ if (!buildCmd) {
     if (!build) { build = { ran: false, clean: false, summary: 'build agent returned nothing' }; break }
     if (build.clean) { log('Build clean after ' + round + ' round(s).'); break }
 
-    const groups = (build.error_groups || []).slice(0, 12)
+    const allGroups = build.error_groups || []
+    const groups = allGroups.slice(0, 12)
     log('Compile round ' + round + ': ' + groups.length + ' error group(s) — dispatching fixers.')
+    if (allGroups.length > groups.length) {
+      droppedErrorGroups += allGroups.length - groups.length
+      log('Capped at 12 of ' + allGroups.length + ' error group(s) this round; ' + (allGroups.length - groups.length) + ' deferred to the next round.')
+    }
     if (!groups.length) break
 
     const fixes = (await parallel(groups.map(g => () => agent([
@@ -481,6 +487,7 @@ if (!buildCmd) {
 // fixers. The suite is the objective signal — an agent never declares "tests
 // pass" without the runner's own marker.
 phase('Test')
+let droppedTestFailures = 0
 let test = { ran: false, green: false, summary: 'no test command provided' }
 
 if (!testCmd) {
@@ -501,8 +508,13 @@ if (!testCmd) {
     if (!test) { test = { ran: false, green: false, summary: 'test agent returned nothing' }; break }
     if (test.green) { log('Test suite green after ' + tround + ' round(s).'); break }
 
-    const fails = (test.failures || []).slice(0, 12)
+    const allFails = test.failures || []
+    const fails = allFails.slice(0, 12)
     log('Test round ' + tround + ': ' + fails.length + ' failing test(s) — dispatching fixers.')
+    if (allFails.length > fails.length) {
+      droppedTestFailures += allFails.length - fails.length
+      log('Capped at 12 of ' + allFails.length + ' failing test(s) this round; ' + (allFails.length - fails.length) + ' deferred to the next round.')
+    }
     if (!fails.length) break
 
     const fixes = (await parallel(fails.map(fl => () => agent([
@@ -528,11 +540,13 @@ if (!testCmd) {
 // Adversarial behavioral check on the highest-risk ported files. Two reviewers
 // per file; if they disagree on the verdict, a third breaks the tie (2-of-3).
 phase('Verify')
-const verifyTargets = ported
+const verifyCandidates = ported
   .filter(p => p.status === 'ported')
   .sort((a, b) => (b.todo_count || 0) - (a.todo_count || 0))
-  .slice(0, Math.min(input.maxVerifyFiles || 24, ported.length))
+const verifyTargets = verifyCandidates.slice(0, Math.min(input.maxVerifyFiles || 24, ported.length))
+const droppedVerifyFiles = verifyCandidates.length - verifyTargets.length
 log('Adversarially verifying ' + verifyTargets.length + ' highest-risk ported file(s) for behavioral fidelity.')
+if (droppedVerifyFiles > 0) log('Capped at ' + verifyTargets.length + ' of ' + verifyCandidates.length + ' ported file(s) — ranked by TODO(migrate) marker count, so the ' + droppedVerifyFiles + ' with the fewest markers are never verified.')
 
 function verifyPrompt(p, lens) {
   return [
@@ -599,6 +613,12 @@ return {
     needs_human: needsHuman.length,
     todos: totalTodos,
     behavioral_mismatches: behavioralMismatches.length,
+  },
+  // What the per-phase caps dropped, so the report can say so instead of implying full coverage.
+  capped: {
+    error_groups: droppedErrorGroups,
+    test_failures: droppedTestFailures,
+    verify_files: droppedVerifyFiles,
   },
   translated: ported.map(p => ({
     source_file: p.source_file, target_file: p.target_file, status: p.status,


### PR DESCRIPTION
# Summary

Finding PR-c6ac9c (medium, repeatability / no-silent-caps): three caps in `skills/migrate-code/migrate-code.workflow.js` dropped work without telling anyone, so a partial migration read as a complete one.

The offending sites, all in migrate mode:

- `const groups = (build.error_groups || []).slice(0, 12)` — compile loop, at most 12 error signatures per round
- `const fails = (test.failures || []).slice(0, 12)` — test loop, at most 12 failing tests per round
- `.slice(0, Math.min(input.maxVerifyFiles || 24, ported.length))` — verify, at most 24 files

None of them said what was excluded. The `log()` after each reported the POST-slice count, so the user saw "12 error group(s)" whether there were 12 or 200. The verify cap was the worst of the three: the preceding sort is by `todo_count` descending, so a cleanly ported file with a real behavioural mismatch and zero TODO markers sorted last and was never checked — yet `SKILL.md` asks the report to list "every `verify` item with `verdict: \"mismatch\"`", so a 60-file migration reported on 24 and read as a full sweep.

This change:

- Captures the pre-slice length at each of the three sites and logs the drop when there is one, in the file's existing conversational log voice. The verify message also names the selection criterion (TODO-marker count), since that is what decides who gets dropped.
- Adds a `capped` key alongside the existing `counts` in the returned object — `{ error_groups, test_failures, verify_files }` — so the report can print the numbers rather than relying on scrollback. The compile and test numbers accumulate across rounds instead of reflecting only the last one.
- Adds a "Verification coverage" bullet to Step 5 (REPORT) in `skills/migrate-code/SKILL.md` requiring the report to state how many ported files were adversarially verified out of how many were ported, and to name what the caps deferred. This is the file's existing "State plainly what is and is not done" principle applied to the caps.

The cap values (12 / 12 / 24) are unchanged — the defect was that they were silent, not that they were wrong.

Observable symptom removed: a run that dropped 176 error groups, 40 failing tests, or 36 unverified files now says so in the log and in the returned payload, and the report is required to disclose verification coverage instead of presenting a capped mismatch list as complete.

Note: `skills/migrate-code/migrate-code.workflow.js` is also touched by the sibling PR `fix/migrate-code-rulebook-truncation`, which owns the `slice(0, 12000)` on the rulebook inside the plan-mode stress agent. This change does not touch plan mode or that region.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: the repo has no test harness for workflow scripts; verified with `node --check` on the workflow and `markdownlint-cli2` on the skill (0 issues)
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The verify drop count is computed as eligible ported files minus verified files, so it reflects exactly what the cap excluded rather than the raw `ported` length (which also includes `blocked` and `skipped-exists` entries that were never verify candidates).
