### PR TITLE
Stress-test the rulebook from disk instead of a truncated copy

### DIFF
--- a/skills/migrate-code/migrate-code.workflow.js
+++ b/skills/migrate-code/migrate-code.workflow.js
@@ -147,6 +147,7 @@ const STRESS_SCHEMA = {
     },
     translation_preview: { type: 'string' },         // short excerpt showing the port, for the human to eyeball
     confidence: { type: 'integer' },                 // 0-100 that the rulebook is ready for full scale
+    notes: { type: 'string' },                       // caveats — e.g. only part of the rulebook could be read
   },
   required: ['file', 'systemic_issues'],
 }
@@ -285,6 +286,9 @@ if (mode === 'plan') {
     '   - what to do when there is NO clean equivalent (the escalation rule: flag with `TODO(migrate): …`)',
     '   - a short "DO NOT" list of tempting-but-wrong translations',
     '   Write it so a smaller model can follow it mechanically on one file at a time.',
+    '   WRITE this rulebook to ' + rulebookPath + ' (create the directory if needed) as well as returning it in',
+    '   `rulebook_markdown` — byte-for-byte the same text. The stress test reads it from that file, so anything',
+    '   you leave out of the file is invisible to it.',
     '',
     '2. DEPENDENCY ORDER (`dependency_order`) — every in-scope source file with its intended target path and',
     '   its in-scope dependencies. Order LEAVES FIRST (files that depend on nothing in scope come first), so',
@@ -309,15 +313,16 @@ if (mode === 'plan') {
 
   phase('StressTest')
   log('Stress-testing the rulebook on ' + sample.length + ' representative file(s) before committing to full scale.')
+  log('The stress agents read the draft rulebook from ' + rulebookPath + ', where the foundation agent wrote it.')
 
   const stress = (await parallel(sample.map(file => () => agent([
     'You are stress-testing a DRAFT migration rulebook by translating ONE representative file end to end.',
     CONTEXT,
     '',
-    'Draft rulebook (not yet written to disk — treat this text as the rulebook):',
-    '"""',
-    String(foundation.rulebook_markdown || '').slice(0, 12000),
-    '"""',
+    'The draft rulebook is on disk at ' + rulebookPath + '. READ IT IN FULL — all of it, including the tail —',
+    'before you translate anything; it is the rulebook under test. If you end up with only part of it (the file',
+    'is long, missing, or empty), say so in `notes` and do NOT report the parts you did not read as rulebook',
+    'gaps — a gap you cannot tell apart from an unread section is not a finding.',
     '',
     'File to translate as a trial: ' + file,
     '',
@@ -332,6 +337,9 @@ if (mode === 'plan') {
   const allIssues = stress.flatMap(s => (s.systemic_issues || []).map(i => ({ ...i, file: s.file })))
   const minConfidence = stress.length ? Math.min(...stress.map(s => (typeof s.confidence === 'number' ? s.confidence : 50))) : 0
   log('Stress-test surfaced ' + allIssues.length + ' systemic rule gap(s); lowest readiness confidence ' + minConfidence + '/100.')
+  for (const s of stress) {
+    if (s.notes) log('Stress caveat (' + (s.file || 'sample') + '): ' + s.notes)
+  }
 
   return {
     mode,


### PR DESCRIPTION
# Summary

Finding PR-7567e7 (medium, repeatability / unenforceable contract): the plan-mode stress test in
`skills/migrate-code/migrate-code.workflow.js` validated a silently truncated copy of the rulebook, so it
manufactured the exact verdict it exists to produce. The stress prompt told the model

> Draft rulebook (not yet written to disk — treat this text as the rulebook):

and then interpolated `String(foundation.rulebook_markdown || '').slice(0, 12000)`. The rulebook the foundation
agent is asked to write must cover idiom mapping, dependency mapping, project conventions, the escalation rule
and a DO-NOT list, all with concrete before/after examples drawn from the codebase — for any non-trivial
migration that comfortably exceeds 12000 characters. Nothing logged the truncation and nothing in the schema
recorded it.

This PR takes the first of the two options in the finding — the rulebook no longer travels through the prompt at
all:

- The Foundation agent now writes the drafted rulebook to `rulebookPath` (byte-for-byte the same text it returns
  in `rulebook_markdown`) alongside producing the dependency order and gap inventory.
- The stress agents read the rulebook from `rulebookPath`, which is exactly what the translate agents already do,
  and the "not yet written to disk" wording is gone.
- The stress prompt tells the agent to read the file in full and, if it ends up with only part of it, to record
  that in `notes` rather than report the unread sections as rulebook gaps.
- `STRESS_SCHEMA` gains a `notes` field and plan mode logs any caveat a stress agent reports, so a partial read
  is loud instead of silent.

This was chosen over the fallback (a bigger cap plus a warning) because it removes the size ceiling entirely
rather than moving it, and it reuses the read-from-disk contract the rest of the workflow already relies on. It
needed no restructuring of plan mode: the script still writes no files, the agents do.

Observable symptom removed: `stress_findings` proposing rule amendments that are already present in
`docs/migration/rulebook.md`, and a `readiness_confidence` — the number Step 3 of `migrate-code/SKILL.md` tells
the user to act on below 70 — depressed by an artifact of the slice.

Scope: plan mode only. Migrate mode (Translate / Compile / Test / Verify) is untouched — the `.slice(0, 12)` /
`maxVerifyFiles` caps in that half of the file are owned by the sibling PR `fix/migrate-code-disclose-caps`,
which touches the same file.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: the repository has no test harness for workflow scripts; the change was verified with `node --check` and a read-through of the plan-mode flow
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The rulebook now lands on disk one step earlier than before. Step 3 of `skills/migrate-code/SKILL.md` still
writes `rulebook_markdown` to `docs/migration/rulebook.md` after plan mode returns and then folds the accepted
stress findings in, which remains correct: it rewrites the same content before amending it.
