### PR TITLE
Reconcile the two block-size ranges and add tie-breaks to the grouping sort

### DIFF
--- a/skills/sprint-summary/SKILL.md
+++ b/skills/sprint-summary/SKILL.md
@@ -151,7 +151,7 @@ Within each repository group, organize items into blocks of approximately 3 work
    - **Staging/QA only**: features needing validation before production
    - **No deployment**: documentation, evaluations, reports, test strategy, planning, CI-only changes
 2. **Never mix delivery targets in the same group**. Items that deploy to production must not be grouped with items that don't. This ensures each group has a clear, unambiguous delivery line.
-3. **Sort items by estimated effort** (largest first) within each delivery target
+3. **Sort items by estimated effort** within each delivery target: largest first, ties broken by issue key ascending
 4. **Create groups using bin-packing**:
    - If a single item is 3+ days, it becomes its own group
    - Otherwise, combine smaller items of the same delivery target until the group totals approximately 3 days (2.5 - 3.5 range is acceptable)
@@ -176,6 +176,7 @@ Output the report in this exact format:
 
 ### Formatting Rules
 
+- Repository groups appear in alphabetical order by normalized group name
 - Group titles are numbered sequentially starting at 1 across the entire report (not per repo)
 - Bullets are indented (3 spaces) under the group title so they appear nested one level below the numbered heading
 - No blank line between the group title and the first bullet
@@ -258,5 +259,5 @@ Use the Jira item status (e.g., "In Code Review", "In Progress", "Done") and des
 - **Write scope**: The skill is read-only by default. The only modification it can ever make to Jira is saving time estimates on items that have none, and only when the user passed `--write-estimates`. Never create, delete, move, or change status of any Jira issues.
 - **Timeout**: Set 15 second timeout on jira commands. If a command hangs, it may be misconfigured.
 - **Link format**: Always use the server URL from the Jira config file, not a hardcoded URL.
-- **Grouping flexibility**: The ~3-day target is approximate. Groups of 2-4 days are acceptable. Prefer logical grouping (related items together) over exact day counts when items are thematically related.
+- **Grouping flexibility**: A multi-item group must total 2.5 - 3.5 days; only a single item of 3+ days may stand outside that range. Group thematically related items together when doing so keeps the group inside that range.
 - **Plain descriptions**: Rephrase Jira summaries into clear, readable descriptions. Remove bracket prefixes, ticket-speak, and jargon.


### PR DESCRIPTION
# Summary

Finding PR-22ac4d (medium) — `skills/sprint-summary/SKILL.md` gave two different, conflicting definitions of an acceptable work block, and left the grouping sort and the report order unordered, so two runs over the same unchanged sprint could produce a different number of groups and a fully renumbered list (`SPRINT.md` diffs end to end).

Failing conditions:

- A 2.2-day group is out of range under Step 5 item 4 ("2.5 - 3.5 range is acceptable") but in range under the Important Rules bullet ("Groups of 2-4 days are acceptable"), and nothing said which wins.
- Step 5 item 3 sorted by "estimated effort (largest first)" with no tie-break, while the six-value estimate grid (0.25/0.5/1/2/3/5) guarantees heavy ties. Because group titles are "numbered sequentially starting at 1 across the entire report", one reordered tie shifts every later group number.
- Repository groups had no stated emission order, so the cross-report numbering was unstable even when the groups themselves were identical.
- "Prefer logical grouping (related items together) over exact day counts" was an unanchored override on top of both ranges.

This change:

- Keeps the more specific 2.5 - 3.5 range in Step 5 and rewrites the Important Rules bullet to agree with it, stating the one exception already in Step 5 (a single item of 3+ days stands alone, so a 5-day item is not a violation).
- Adds a tie-break to the Step 5 sort: largest effort first, then issue key ascending.
- States that repository groups appear in alphabetical order by normalized group name.
- Bounds the thematic override so related items are grouped together only when the merged group stays inside 2.5 - 3.5.

Step 7 (FTE / load-table capacity math) is deliberately untouched — a separate PR covers it.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: This repo ships Markdown skill prompts, not runnable code, so there is nothing to unit test. Verified with `npx markdownlint-cli2 skills/sprint-summary/SKILL.md` (0 issues) and by re-reading the skill end to end for remaining range or ordering contradictions.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The edits pin contracts (one range, one sort order, one report order) rather than adding procedure. Three lines changed, one added.
