### PR TITLE
Scope SL0002 to [[ ]] so it stops introducing shellcheck SC3014

### DIFF
--- a/skills/run-linters/SKILL.md
+++ b/skills/run-linters/SKILL.md
@@ -168,16 +168,21 @@ echo "${HOME}/.local/bin:${PATH}"
 if [ "${CURRENT_BRANCH}" != "${MASTER_BRANCH}" ]; then
 ```
 
-### SL0002: Use `==` instead of `=` for string comparison
+### SL0002: Use `==` instead of `=` for string comparison — inside `[[ ]]` only
 
-In `[` and `[[` test expressions, use `==` for string equality, not `=`.
+In `[[ ]]` test expressions, use `==` for string equality, not `=`.
+
+Inside single-bracket `[ ]`, keep `=`. `==` is not POSIX there: shellcheck reports SC3014 and dash fails at runtime with `test: ==: unexpected operator`. Never rewrite `=` to `==` in a `#!/bin/sh` script.
 
 ```bash
 # Bad
-if [ "${CONFIGURATION}" = "Debug" ]; then
+if [[ "${CONFIGURATION}" = "Debug" ]]; then
 
 # Good
-if [ "${CONFIGURATION}" == "Debug" ]; then
+if [[ "${CONFIGURATION}" == "Debug" ]]; then
+
+# Also correct - leave as is
+if [ "${CONFIGURATION}" = "Debug" ]; then
 ```
 
 ### General Shell Script Fixes


### PR DESCRIPTION
# Summary

Finding **PR-d61523** (high): rule SL0002 in `skills/run-linters/SKILL.md` told the model to use `==` instead of `=` for string equality "In `[` and `[[` test expressions", with a worked example rewriting `if [ "${CONFIGURATION}" = "Debug" ]; then` into `if [ "${CONFIGURATION}" == "Debug" ]; then`.

`==` inside single-bracket `[ ]` is not POSIX. On a `#!/bin/sh` script that rewrite makes a clean line fail: `shellcheck` emits SC3014 ("In POSIX sh, == in place of = is undefined") and dash breaks at runtime with `test: ==: unexpected operator`. Confirmed locally — a `#!/bin/sh` script containing `if [ "$A" == "b" ]` reports SC3014 and exits 1. That put the run-linters skill in the position of introducing a shellcheck error while its own Important Rules forbid silencing it with a disable comment.

This change scopes SL0002 to `[[ ]]` only, states that `=` must be kept inside `[ ]` (naming SC3014 and the dash failure as the reason), adds the shebang rule that `=` is never rewritten to `==` in a `#!/bin/sh` script, and updates the Bad/Good example so both forms use `[[ ]]` plus an "also correct" `[ ... = ... ]` line. SL0001 and the "General Shell Script Fixes" bullets are untouched.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: This repo ships Markdown skill prompts, not runnable code. The rule was verified by running `shellcheck` on throwaway `#!/bin/sh` and `#!/bin/bash` scripts (zero SC3014 on the forms the rule now prescribes; SC3014 reproduced on the form it previously prescribed), and `npx markdownlint-cli2` on the edited file reports 0 issues.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The correctness rule (`[ ]` keeps `=`, `[[ ]]` takes `==`, never rewrite in `#!/bin/sh`) is stated in two sentences; no procedural how-to-lint text was added. The existing "Use `[[` over `[` when possible" bullet under General Shell Script Fixes already complements this and was left alone.
