### PR TITLE
Give the fidelity score a fixed denominator so runs are comparable

### DIFF
--- a/skills/review-design/SKILL.md
+++ b/skills/review-design/SKILL.md
@@ -102,7 +102,9 @@ Ask the user to confirm which files correspond to the design if the mapping is n
 
 ## Step 4: Compare Design vs Code
 
-For each aspect below, compare the Figma design values against the code implementation. Record findings as MATCH, MISMATCH, or MISSING.
+**Element set** — the frames and components returned by `mcp__figma__get_design_context` for the supplied URL, in the order returned.
+
+Compare each of the 8 aspects below against every element in that set, and emit exactly one row per aspect x element with a MATCH, MISMATCH, or MISSING verdict. An aspect that matches is a MATCH row, not an omission — the findings table always has `8 x elements` rows.
 
 ### 4.1 Layout Structure
 
@@ -171,9 +173,11 @@ For each aspect below, compare the Figma design values against the code implemen
 
 ### Findings
 
-| # | Aspect | Status | Figma Value | Code Value | File:Line | Severity |
-|---|--------|--------|-------------|------------|-----------|----------|
-| 1 | {aspect} | MATCH/MISMATCH/MISSING | {value} | {value} | {file:line} | {LOW/MEDIUM/HIGH} |
+Sorted by severity (HIGH, MEDIUM, LOW, then MATCH rows, which have no severity), then aspect in Step 4 order, then element in Figma order.
+
+| # | Element | Aspect | Status | Figma Value | Code Value | File:Line | Severity |
+|---|---------|--------|--------|-------------|------------|-----------|----------|
+| 1 | {element} | {aspect} | MATCH/MISMATCH/MISSING | {value} | {value} | {file:line} | {LOW/MEDIUM/HIGH} |
 
 ### Severity Guide
 - **HIGH** — Visually noticeable difference (wrong color, missing component, broken layout)
@@ -181,7 +185,7 @@ For each aspect below, compare the Figma design values against the code implemen
 - **LOW** — Minor inconsistency (spacing off by 1-2px, slightly different corner radius)
 
 ### Summary
-- **Total checks:** {count}
+- **Total checks:** {8 x number of elements}
 - **Matches:** {count}
 - **Mismatches:** {count}
 - **Missing:** {count}
@@ -194,6 +198,8 @@ For each aspect below, compare the Figma design values against the code implemen
 **Ask the user before making changes:**
 
 > "I found {N} discrepancies between the design and code. Would you like me to fix them?"
+
+`{N}` is mismatches + missing.
 
 ## Step 6: Apply Fixes (if user approves)
 


### PR DESCRIPTION
# Summary

Finding **PR-32fbeb** (medium) — `skills/review-design/SKILL.md`.

Step 5 reports `Total checks`, `Matches` and `Fidelity score: {matches / total * 100}%`, but nothing pinned `total`. Step 4 lists 8 aspects without saying how many checks each contributes or over which elements, and it said only "record findings", so a matching aspect could be silently omitted. Running the skill twice on the same Figma frame and the same unchanged code could therefore produce, say, 12 rows one run and 30 the next: the percentage moved with the denominator rather than with fidelity, and the `"I found {N} discrepancies... Would you like me to fix them?"` gate — and hence the size of the diff the user approves — moved with it too.

This change pins the output contract:

- Step 4 defines the element set deterministically (the frames/components returned by `mcp__figma__get_design_context` for the supplied URL, in the order returned) and requires exactly one row per aspect x element with a MATCH / MISMATCH / MISSING verdict — a matching aspect is a MATCH row, not an omission. `total` is therefore `8 x elements` and stable across runs.
- Step 5 states `Total checks: {8 x number of elements}`, adds an `Element` column so each row's identity is visible, and gives the findings table a stated sort order (severity, then aspect in Step 4 order, then element in Figma order) so row numbering does not churn between runs.
- The approval gate states `{N}` is mismatches + missing.

No change to the Step 4 comparison guidance itself.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts, not runnable code; verified with `npx markdownlint-cli2 skills/review-design/SKILL.md` (0 issues).
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

The fix is deliberately leaner than the finding's phrasing: one sentence in Step 4 covers both the per-cell verdict rule and the `8 x elements` denominator instead of restating the aspect list, and no procedural guidance was added about how to enumerate or compare elements.
