### PR TITLE
Check out each issue branch before handing it to create-pr

### DIFF
--- a/skills/work-issue/SKILL.md
+++ b/skills/work-issue/SKILL.md
@@ -131,10 +131,10 @@ Present a compact per-issue summary from `results`: outcome, branch, `test_statu
 
 Once the user is happy, use `AskUserQuestion` to decide how to ship the successful branches:
 
-- **Separate PRs (one per issue)** — for each successful result, open a PR from its branch via the `create-pr` skill, using its `pr_title` and adding its `closing_keyword` to the PR **body** (GitHub). This is the default when the issues are unrelated.
+- **Separate PRs (one per issue)** — `create-pr` takes no branch argument; it pushes and opens the PR for whatever branch is checked out. So for each successful result, `git checkout <branch>` in the main checkout **first**, then invoke `create-pr` with its `pr_title`, adding its `closing_keyword` to the PR **body** (GitHub). `create-pr` returns the tree to the default branch, so the next result starts clean. This is the default when the issues are unrelated.
 - **Single combined PR** — create one integration branch from `origin/$DEFAULT_BRANCH`, merge each successful issue branch into it (`git merge --no-ff <branch>` per issue; resolve any conflicts, re-run tests), then open one PR via `create-pr`. Put **every** issue's closing keyword on its own line in the body (`Closes #123`, `Fixes #124`, …) so all of them auto-close on merge. Use this when the issues are tightly related or the user wants a single review.
 
-In both cases the `create-pr` skill handles running tests locally, pushing, opening the PR, and watching CI (via the Actions runs REST API) — do not `git push` / `gh pr create` yourself. After PRs are open, run Steps 10–11 (update issue, post the tester QA checklist) per issue, and for Jira transition each to **Code Review**. Then clean up worktrees (`git worktree remove .worktrees/<branch>` or the workflow's temporary worktrees) once the user confirms, preserving the branches until the PRs merge.
+In both cases the `create-pr` skill handles running tests locally, pushing, opening the PR, and watching CI (via the Actions runs REST API) — do not `git push` / `gh pr create` yourself. After PRs are open, run Steps 10–11 (update issue, post the tester QA checklist) per issue, and for Jira transition each to **Code Review**. No worktree cleanup is needed here: the workflow's worktrees are harness-managed and already gone, and the issue branches persist in the shared object store — leave them until the PRs merge.
 
 ---
 


### PR DESCRIPTION
# Summary

Finding **PR-c467e5** (high) — `skills/work-issue/SKILL.md`, parallel mode, section "P4 — Ask: separate PRs or one combined PR?".

**Failing condition:** run `work-issue` with two or more refs (e.g. `123 124`), let the workflow succeed, then pick "Separate PRs". P4 said to "open a PR from its branch via the `create-pr` skill" — but `create-pr` takes no branch argument. Its Step 1 reads `CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)`, Step 3 runs `git add -A` and commits, Step 5 runs `git push -u origin "$CURRENT_BRANCH"`, Step 6 opens the PR with `--head "$CURRENT_BRANCH"`. After the workflow returns, the main checkout is still on the default branch. So `create-pr` would stage and commit any loose files onto the **default branch**, push it, and open a PR whose head equals its base — while the actual issue branches are never pushed.

**Second defect in the same paragraph:** cleanup pointed at `git worktree remove .worktrees/<branch>`. Parallel mode never creates `.worktrees/` — that directory only exists on the *sequential* Path B (Step 3). The parallel path uses `isolation: 'worktree'` in `work-issue.workflow.js`, whose worktrees are harness-managed and already removed by the time P4 runs, while the branches persist in the shared object store.

**What changed** (two sentences in P4, no other edits):

1. The "Separate PRs" bullet now states the `create-pr` contract — no branch argument, it acts on whatever is checked out — and requires `git checkout <branch>` in the main checkout before each invocation. It also notes `create-pr` returns the tree to the default branch, so each iteration starts clean.
2. The cleanup sentence now says no worktree cleanup is needed in parallel mode (harness-managed worktrees, branches persist), replacing the `.worktrees/<branch>` command that belongs only to sequential Path B. Step 12 (sequential cleanup) is untouched and still correct.

**Alternative considered and rejected as out of scope:** give `create-pr` an explicit branch parameter. That is a contract change affecting every caller of the skill, so it was deliberately not done here; `create-pr` is unmodified.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts, not runnable code — there is no unit under test. Verified instead by reading `skills/create-pr/SKILL.md` to confirm the `CURRENT_BRANCH` / `git push -u origin "$CURRENT_BRANCH"` / `--head "$CURRENT_BRANCH"` contract and its return-to-default-branch step, by confirming `isolation: 'worktree'` in `skills/work-issue/work-issue.workflow.js`, and by running `npx markdownlint-cli2 skills/work-issue/SKILL.md` (0 issues).
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The edit pins a contract (`create-pr` acts on the checked-out branch) and corrects a domain fact (which path creates `.worktrees/`) rather than prescribing procedure. The finding also suggested spelling out "its own Bash call, per the direnv rule"; that was left out — the file's direnv rule is specifically about not chaining `cd` with a credentialed command, and P1 has already `cd`'d into the repo, so a plain `git checkout` needs no such warning.
