### PR TITLE
Correct the claim that monday read-only is enforced by configuration

### DIFF
--- a/skills/doc-tracker-coverage/SKILL.md
+++ b/skills/doc-tracker-coverage/SKILL.md
@@ -55,7 +55,7 @@ export MONDAY_TOKEN="your_monday_api_token"   # avatar → Developers → My acc
 claude mcp add monday --transport http https://mcp.monday.com/mcp --header 'Authorization: Bearer ${MONDAY_TOKEN}'
 ```
 
-If `mcp__monday__*` tools are absent (tool-not-found), the server is not added or `MONDAY_TOKEN` is unset. Only fail the **monday side** of teams configured for monday — disclose it in the report ("monday unavailable — monday-tracked teams not verified") and still verify the Jira side. **Only ever issue read queries** through `all_monday_api` (`query { … }`, never `mutation`); the write-capable monday tools are deliberately excluded from `allowed-tools`.
+If `mcp__monday__*` tools are absent (tool-not-found), the server is not added or `MONDAY_TOKEN` is unset. Only fail the **monday side** of teams configured for monday — disclose it in the report ("monday unavailable — monday-tracked teams not verified") and still verify the Jira side. The write-capable monday tools are **excluded from `allowed-tools`**. `all_monday_api` *is* granted — board enumeration and bulk item paging need it — and it is a general GraphQL passthrough that *could* mutate, so read-only on that one tool is a **prompt-level rule, not a configuration guarantee**: **only ever issue read queries through it** (`query { … }`, never `mutation`).
 
 ### Jira (MCP first, curl/CLI fallback) — run from the target repo's directory (direnv)
 

--- a/skills/monday-weekly-report/SKILL.md
+++ b/skills/monday-weekly-report/SKILL.md
@@ -38,7 +38,7 @@ All tool calls execute as that user and are subject to their monday.com permissi
 
 ## MCP tools and the snapshot-vs-activity-log split
 
-This skill calls **read tools only**. The write-capable monday tools (`create_*`, `change_item_column_values`, `move_item_to_group`, `delete_*`, `create_update`) are deliberately **excluded from `allowed-tools`** so the read-only guarantee is enforced by configuration, not just prose. `all_monday_api` is a general GraphQL passthrough that *could* mutate — **only ever issue read queries through it** (`query { … }`, never `mutation`).
+This skill calls **read tools only**. The write-capable monday tools (`create_*`, `change_item_column_values`, `move_item_to_group`, `delete_*`, `create_update`) are **excluded from `allowed-tools`**. `all_monday_api` *is* granted — bulk item paging and activity-log reads need it — and it is a general GraphQL passthrough that *could* mutate, so read-only on that one tool is a **prompt-level rule, not a configuration guarantee**: **only ever issue read queries through it** (`query { … }`, never `mutation`).
 
 | Operation | Tool | Notes |
 | --- | --- | --- |


### PR DESCRIPTION
# Summary

Finding **PR-1b3ca0** (medium) from the prompt review of the `co-dev` plugin.

`skills/monday-weekly-report/SKILL.md`, in "MCP tools and the snapshot-vs-activity-log split", claimed the write-capable monday tools are excluded from `allowed-tools` "so the read-only guarantee is enforced by configuration, not just prose" — and then in the very next sentence conceded that `all_monday_api` "is a general GraphQL passthrough that *could* mutate".

The failing condition: `mcp__monday__all_monday_api` **is** listed in that same file's `allowed-tools` frontmatter. A single `mutation { ... }` sent through that passthrough writes to live monday.com data with no configuration-level barrier. The read-only guarantee is therefore enforced by prose, not configuration, and the sentence claiming otherwise is exactly the line a reader or auditor would rely on. `skills/doc-tracker-coverage/SKILL.md` carried a near-identical clause with the same grant.

This change corrects the accuracy claim in both files, keeping their near-duplicate paragraphs aligned. Each now states that the named write tools are excluded from `allowed-tools`, that `all_monday_api` *is* granted and why (activity-log reads and bulk item paging in monday-weekly-report; board enumeration and bulk item paging in doc-tracker-coverage), and that read-only on that one tool is a **prompt-level rule, not a configuration guarantee** — only ever `query { … }`, never `mutation`.

This does **not** relax the rule: the existing read-only instructions are kept intact, only the false claim about how they are enforced is corrected. Wording-only change; no behavioural instruction was altered.

Alternative considered and deliberately **not** taken: removing `mcp__monday__all_monday_api` from `allowed-tools` would make the original "enforced by configuration" claim true, but it would cost bulk item paging (and thus full-board coverage) and the activity-log attribution mode in `monday-weekly-report`, plus board enumeration in both skills. That is a maintainer call, not a doc fix — flagging it here rather than doing it.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: This repo ships Markdown skill prompts, not runnable code — there is no unit under test. Verified with `npx markdownlint-cli2` on both files (0 issues) and by confirming `mcp__monday__all_monday_api` is present in each file's `allowed-tools` frontmatter, which is what makes the original claim false.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

Both paragraphs were near-duplicates before this change and remain aligned after it, so the two skills keep telling the reader the same story about the monday read-only posture.
