### PR TITLE
Fix the live-mode page sample and finding order so runs are comparable

### DIFF
--- a/skills/review-seo/SKILL.md
+++ b/skills/review-seo/SKILL.md
@@ -77,7 +77,9 @@ For **codebase** mode, resolve the concrete files. For **live** mode, this is in
 
 ## Phase 4: Technical SEO Audit
 
-For each item, gather evidence per the Evidence rule. In **codebase** mode, read templates/config; in **live** mode, fetch the homepage plus a representative sample of page types (e.g. one content page, one listing) and inspect served HTML/headers.
+For each item, gather evidence per the Evidence rule. In **codebase** mode, read templates/config; in **live** mode, fetch the **page sample** below and inspect served HTML/headers.
+
+**Page sample** (fixed — every later phase that inspects a subset of pages uses this same set): the homepage, plus the first **5** `sitemap.xml` URLs in document order, deduplicated by path template (`/blog/:slug` counts once); if there is no sitemap, the first 5 internal links on the homepage in document order. Record the sampled URLs in the report header.
 
 ### 4.1 Meta & titles
 
@@ -146,7 +148,7 @@ Validate: the file exists, parses to that shape, links resolve, and it points at
 
 ### 5.3 Per-page Markdown versions
 
-- Spec convention: a clean Markdown twin of each HTML page reachable by appending `.md` (or `index.html.md` for directory URLs) — an LLM-readable version of the page. Sample a few pages and check whether a `.md` version is served (200 + Markdown) and matches the page's real content. Absent → Info/Low opportunity; recommend generating them at build time.
+- Spec convention: a clean Markdown twin of each HTML page reachable by appending `.md` (or `index.html.md` for directory URLs) — an LLM-readable version of the page. Across the Phase 4 page sample, check whether a `.md` version is served (200 + Markdown) and matches the page's real content. Absent → Info/Low opportunity; recommend generating them at build time.
 
 ### 5.4 AI-crawler policy (robots.txt + headers + WAF)
 
@@ -248,6 +250,8 @@ Pre-report verification: every applicable phase task is complete and each findin
 | 🔵 Low | Alt-text gaps, non-descriptive link text, minor polish |
 | ⚪ Info | Observations, GEO opportunities, FYI |
 
+Sort findings by severity (Critical → High → Medium → Low → Info), then by Area, then by evidence path; assign the `SEO-001…` ids only after sorting.
+
 Write `docs/seo-audit.md` (`mkdir -p docs` first). Structure:
 
 ```markdown
@@ -256,6 +260,7 @@ Write `docs/seo-audit.md` (`mkdir -p docs` first). Structure:
 **Project:** [name]
 **Scan mode:** codebase | live | both
 **Target:** [base_url and/or repo]
+**Pages sampled:** [the page sample URLs, or N/A in codebase mode]
 **Date:** [ISO-8601]
 
 ## Summary
@@ -336,6 +341,7 @@ If any files changed, run `/co-dev:run-linters` and fix any errors (including ma
 - [ ] Performance: field data (CrUX/Search Console) preferred; INP checked specifically
 - [ ] Headings, alt text, link text, orphans, broken links checked
 - [ ] Web quality via bundled chrome-devtools MCP: performance, CWV (LCP·INP·CLS), accessibility (WCAG), best-practices audited — or marked not-run
+- [ ] Page sample listed in the report header; findings sorted before `SEO-00N` ids assigned
 - [ ] `docs/seo-audit.md` written; approval requested before fixes
 
 ## Important Rules


### PR DESCRIPTION
# Summary

Finding PR-0603b0: `skills/review-seo/SKILL.md` never said which pages a live-mode run should look at. Phase 4 asked for "the homepage plus a representative sample of page types (e.g. one content page, one listing)" and Phase 5.3 separately asked to "sample a few pages" — no count, no selection rule. Findings are also emitted with no stated sort key, so `SEO-001…` ids are assigned in whatever order the checks happen to finish.

Consequence on an unchanged site: two runs sample different pages (one hits a page with a missing canonical and raises a High finding the other run never sees), the Summary severity counts move, and the ids renumber. A `git diff` of `docs/seo-audit.md` between runs shows resampling and renumbering instead of real change.

This change pins two output contracts:

- **Sample.** Phase 4 now defines a fixed *page sample* — the homepage plus the first 5 `sitemap.xml` URLs in document order deduplicated by path template, or the first 5 internal homepage links in document order when there is no sitemap. Phase 5.3 references that sample instead of restating its own rule. The sampled URLs are recorded in a new `**Pages sampled:**` line in the report header so a reader sees what was covered.
- **Order.** Phase 8 now sorts findings by severity (Critical → High → Medium → Low → Info), then Area, then evidence path, matching the convention already in `skills/code-review-deep/SKILL.md`, and states that `SEO-001…` numbering happens only after sorting.

One Validation Checklist line covers both. Net +6 lines; no method guidance was added for any individual check.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: This repo ships Markdown skill prompts, not runnable code; verification is `npx markdownlint-cli2 skills/review-seo/SKILL.md`, which reports 0 issues.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

N = 5 is a judgement call — large enough to cover a homepage plus a few distinct path templates, small enough not to slow a live run. It is stated as a number rather than a range so two runs over the same site cover the same pages.
