### PR TITLE
Stop the sprint goal reading Off track whenever no work is done yet

### DIFF
--- a/skills/weekly-dev-report/SKILL.md
+++ b/skills/weekly-dev-report/SKILL.md
@@ -545,6 +545,8 @@ The point of this section is to tell the reader, in one glance, whether the spri
    - 🔴 **Off track** — `completion_pct < expected_pct − 0.25`, OR `required_rate > current_rate × 1.75`, OR `working_days_left ≤ 0` with `remaining_work > 0`.
    - 🟡 **At risk** — behind by 10–25 points (`expected_pct − completion_pct` in `[0.10, 0.25]`), OR `required_rate` is `1.25×–1.75×` the current rate.
    - 🟢 **On track** — otherwise (`completion_pct ≥ expected_pct − 0.10` and `required_rate ≤ current_rate × 1.25`).
+
+   The two `current_rate` ratio tests apply **only when `current_rate > 0`**. When nothing has completed yet (`current_rate = 0`) the ratio is undefined, not infinite — skip both tests and decide from `completion_pct` vs `expected_pct` alone (the `working_days_left ≤ 0` condition still stands, it is rate-independent). Otherwise every sprint reads 🔴 for its first few days. Say so in the Verdict line: no work has completed yet, so the burn ratio is not yet meaningful.
 5. **At-risk items.** Build the concrete list of what jeopardizes the goal — each with owner (+role), the reason, and a recommended action. Draw from:
    - Not-started or blocked tickets with the largest remaining estimate, and any P1/blocker priority.
    - Stuck tickets (the 🚩 flag above).
@@ -588,7 +590,7 @@ Write to `WEEKLY_REPORT.md` in the current working directory, and print the same
 **Sprint goal status:** <🟢 On track | 🟡 At risk | 🔴 Off track> <br>
 **Progress:** <done_work>/<total_work> <points|tickets> done = <completion_pct>% (≈<expected_pct>% expected by today) <br>
 **Burn:** <current_rate>/day actual vs <required_rate>/day required to finish — <working_days_left> working days left <br>
-**Verdict:** <one sentence: on pace, or "N units behind, needs X/day (Y× current) to catch up">
+**Verdict:** <one sentence: on pace, or "N units behind, needs X/day (Y× current) to catch up"; when `current_rate` is 0, drop the `Y× current` ratio and say "nothing completed yet — needs X/day; burn ratio not yet meaningful">
 
 ### At-risk items
 


### PR DESCRIPTION
<!-- Distributed by repos.sh from Cloud-Officer/aws:github/PULL_REQUEST_TEMPLATE-generic.md - edit it there, local changes are overwritten. -->

# Summary

Finding **PR-dd3c01** in `skills/weekly-dev-report/SKILL.md`, Step 6 "Delivery risk assessment".

Item 3 defines `current_rate = done_work / max(elapsed_working_days, 0.5)`. Item 4 then decides the sprint-goal status with, first match wins, `required_rate > current_rate × 1.75` for 🔴 and `1.25×–1.75×` for 🟡. The `max(…, 0.5)` guard protects the denominator, but nothing guards the multiplier comparison: whenever `done_work` is 0, `current_rate` is 0, `current_rate × 1.75` is 0, and `required_rate > 0` is true for any sprint with work left. 🔴 is evaluated first, so it fires before 🟡 and 🟢 are ever reached.

Failing condition: day 1 of a 10-working-day sprint, 40 points of scope, nothing closed. `expected_pct` = 0.10, `completion_pct` = 0.00, so the linear-burn test correctly does not fire (a 0.10 gap is inside tolerance) — but `required_rate` = 4.0 vs `current_rate` = 0 makes the headline read "🔴 Off track", and Step 7 renders the full Delivery-risk section, at-risk list and catch-up plan for a sprint that is exactly on pace. On a two-week sprint this is routinely the first three or four days.

The change adds one qualifier to item 4: the two `current_rate` ratio tests apply only when `current_rate > 0`; when it is 0 the ratio is undefined rather than infinite, so both are skipped and the status is decided from `completion_pct` vs `expected_pct` alone, with the Verdict line saying no work has completed yet. The rate-independent `working_days_left ≤ 0` with `remaining_work > 0` condition is explicitly kept. Step 7's Verdict template is updated to match (drop the `Y× current` ratio, which was also a divide-by-zero, and state that the burn ratio is not yet meaningful). Per-member rating bands on `pr_per_day` are untouched.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts, not runnable code, so there is no unit under test; verified instead by running `npx markdownlint-cli2 skills/weekly-dev-report/SKILL.md` (0 issues) and by re-walking the worked example above through the amended item 4.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

Scoped deliberately: the finding suggested a broader rewrite of item 4, but the defect is entirely in the missing guard on the two ratio tests, so this pins that one contract and leaves the three status bullets as written.
