### PR TITLE
Stop the background CI watch looping forever when there is no Actions run

### DIFF
--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -137,20 +137,13 @@ If a PR already exists for `$CURRENT_BRANCH` (e.g., the caller already opened it
 
 A pushed PR is not done until its checks are green — but CI can take several minutes, so **watch it without blocking the session**. Launch the watch as a background task, then continue straight to Step 8. The background watch re-invokes you when CI settles, so a failure is still caught and triaged in this session — just not by sitting idle.
 
-**Read CI status with the Actions runs REST API — not `gh pr checks`.** This workflow authenticates with a **fine-grained PAT**, which has no "Checks" permission (the Checks API is GitHub-App-only), so `gh pr checks` always fails here with `Resource not accessible by personal access token` on `statusCheckRollup...contexts`. Do not use it. The REST `actions/runs` endpoint uses the `Actions` permission the PAT does have:
+**Read CI status with the Actions runs REST API — not `gh pr checks`.** This workflow authenticates with a **fine-grained PAT**, which has no "Checks" permission (the Checks API is GitHub-App-only), so `gh pr checks` always fails here with `Resource not accessible by personal access token` on `statusCheckRollup...contexts`. Do not use it. The REST `actions/runs` endpoint uses the `Actions` permission the PAT does have.
 
-```bash
-SHA=$(git rev-parse "$CURRENT_BRANCH")
-# Poll until the run completes, then list each job's conclusion.
-while :; do
-  read -r STATUS RUN_ID < <(gh api "repos/{owner}/{repo}/actions/runs?head_sha=$SHA&event=pull_request&per_page=1" --jq '.workflow_runs[0] | "\(.status) \(.id)"')
-  [ "$STATUS" = "completed" ] && break
-  sleep 30
-done
-gh api "repos/{owner}/{repo}/actions/runs/$RUN_ID/jobs" --jq '.jobs[] | {name, status, conclusion}'
-```
+Write a bounded poll (~30s between polls) over `gh api "repos/{owner}/{repo}/actions/runs?head_sha=$SHA&event=pull_request&per_page=1"` for the SHA you just pushed (`git rev-parse "$CURRENT_BRANCH"`), and run it with the Bash tool's **`run_in_background: true`** (never in the foreground) so the session is not blocked; it re-invokes you when it exits. It must exit on **each** of these — a poll whose only exit is "run completed" spins forever, detached and unwatched, on a repo with no `.github/workflows/`:
 
-Run the loop with the Bash tool's **`run_in_background: true`** (do not foreground it) so the session is not blocked; it re-invokes you when the run completes. Any job `conclusion` other than `success` / `skipped` / `neutral` is a failure.
+- **The run reached `completed`:** list each job with `gh api "repos/{owner}/{repo}/actions/runs/$RUN_ID/jobs"` and report the conclusions. Any job `conclusion` other than `success` / `skipped` / `neutral` is a failure.
+- **No run for the SHA after ~2 minutes:** there is no CI to wait on — say so and stop. The grace period covers the seconds between the push and the run registering, so a just-queued run is not missed.
+- **Still not `completed` after ~30 minutes:** stop and report the run as stuck rather than polling on.
 
 > **Xcode Cloud:** its result only surfaces as a *check run*, which the fine-grained PAT cannot read — so it does **not** appear in `actions/runs`. For Xcode Cloud pass/fail and logs, use the `appstore` skill.
 
@@ -160,8 +153,6 @@ When the background watch completes:
 - **A job failed:** Step 8 has likely already returned you to the default branch, so re-checkout the PR branch first (`git checkout "$CURRENT_BRANCH"`), then pull the failing logs, fix the cause, and push again (re-run Steps 4–7). Do not leave the PR with a red required check.
   - GitHub Actions: `gh run view "$RUN_ID" --log-failed`.
   - **Xcode Cloud:** the check tells you only pass/fail. For the failing test names and logs, use the `appstore` skill — `asc-mcp` does not expose the `ci*` endpoints, so the failing `.xcresult` must be fetched via the App Store Connect API and read with `xcrun xcresulttool`.
-
-If `actions/runs` returns no run for the SHA and the repo has no Actions workflows, there is no CI to wait on — note that and continue.
 
 ## Step 8: Return to Default Branch
 
@@ -246,5 +237,5 @@ If the section is required, write a paragraph explaining the breaking changes, c
 - NO emojis unless explicitly requested
 - Before generating PR content, ensure the `run-linters` skill has been executed to verify code quality
 - Run the existing test suite locally before pushing (Step 4) — for Swift/iOS that means `swift test` or `xcodebuild test`, which run on this Mac; never push a behavior change without running its tests, and never claim tests pass without the runner's own pass marker
-- After pushing, watch CI **in the background** (Step 7) — read status with the Actions runs REST API (`actions/runs?head_sha=…` → `/jobs`), not `gh pr checks` (the fine-grained PAT can't read check runs). Run the poll loop with `run_in_background: true` so the session is not blocked, then triage when it reports; the PR is not done while a required check is red. Xcode Cloud results don't appear in `actions/runs` — use the `appstore` skill for those.
+- After pushing, watch CI **in the background** (Step 7) — read status with the Actions runs REST API (`actions/runs?head_sha=…` → `/jobs`), not `gh pr checks` (the fine-grained PAT can't read check runs). Run the poll with `run_in_background: true` so the session is not blocked, and bound it so it also exits when no run exists for the SHA; then triage when it reports — the PR is not done while a required check is red. Xcode Cloud results don't appear in `actions/runs` — use the `appstore` skill for those.
 - The skill is not done until Step 8 has run (or has been deliberately skipped because of a worktree). Do not stop after printing the Step 2 block.


### PR DESCRIPTION
# Summary

Finding **PR-f39ba2** (high) from the `co-dev` prompt review: Step 7 of `skills/create-pr/SKILL.md` ("Monitor CI in the Background") shipped a literal `while :; do … done` bash loop whose only exit was `[ "$STATUS" = "completed" ]`, to be launched with `run_in_background: true`.

Failing condition: on a repo with no `.github/workflows/` — and in the seconds after a push before a run registers — `actions/runs?head_sha=…` returns an empty `workflow_runs` array, `.workflow_runs[0]` is null, `$STATUS` is never `completed`, and the detached loop polls every 30s forever with nothing watching it. The file's own escape hatch ("If `actions/runs` returns no run for the SHA and the repo has no Actions workflows, there is no CI to wait on") sat after the loop, unreachable from any branch inside it.

**Key changes:**

- Replaced the copy-paste poll loop with a statement of intent plus the three terminating conditions the watch must honour: the run reached `completed` (list jobs, report conclusions), no run for the SHA after a ~2 minute grace period (no CI to wait on — say so and stop), and still not `completed` after ~30 minutes (report the run as stuck rather than polling on). The grace period keeps a just-queued run from being missed while still guaranteeing termination.
- Kept every load-bearing fact in substance: status must be read from the REST `actions/runs` endpoint because the fine-grained PAT has no Checks permission and `gh pr checks` 403s; the `actions/runs/$RUN_ID/jobs` endpoint and the `success` / `skipped` / `neutral` pass set; the `run_in_background: true` requirement; and the caveat that Xcode Cloud results never appear in `actions/runs` (use the `appstore` skill).
- Removed the now-redundant trailing "no run for the SHA" sentence, which is folded into the terminating conditions.
- Updated the matching bullet in "Important Rules" so it also states the no-run exit.

Over-specification note: the exact bash was procedure a frontier model derives on its own, so it was dropped rather than patched; the endpoint paths, the `gh pr checks` prohibition, the thresholds, the pass set and the Xcode Cloud caveat are contracts the model cannot derive, and those were kept — as inline code inside prose rather than a fenced block. Net effect is a shorter Step 7 that is also correct.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts, not runnable code, so there is nothing to unit test; verified with `npx markdownlint-cli2 skills/create-pr/SKILL.md` (0 issues).
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
