### PR TITLE
Derive sprint capacity from the actual sprint length instead of assuming a month

### DIFF
--- a/skills/sprint-summary/SKILL.md
+++ b/skills/sprint-summary/SKILL.md
@@ -48,12 +48,14 @@ This skill uses MCP tools when available and falls back gracefully if they are u
 1. **Determine the sprint**: The user provides a sprint ID or name. If not provided, use the current active sprint:
 
    ```bash
-   jira sprint list --state active --table --plain --no-headers --columns ID,NAME
+   jira sprint list --state active --table --plain --no-headers --columns ID,NAME,START,END
    ```
 
    If multiple active sprints exist, ask the user which one to use.
 
-2. **Extract the Jira server URL** for building browse links — prefer the env var, fall back to the jira-cli config (path varies by platform):
+2. **Record the sprint's start and end dates.** Step 7 derives capacity from them, so never assume a sprint length. When the user named a specific sprint, drop `--state active` from the command above and take the row whose ID matches.
+
+3. **Extract the Jira server URL** for building browse links — prefer the env var, fall back to the jira-cli config (path varies by platform):
 
    ```bash
    JIRA_SERVER="${JIRA_URL:-$(grep -h '^server:' \
@@ -214,12 +216,14 @@ Use the Jira item status (e.g., "In Code Review", "In Progress", "Done") and des
 3. At the end, add a brief stats line:
 
    ```text
-   Sprint: <sprint name> | <total items> items | ~<total estimated days> days of work | ~<FTE> full-time developers
+   Sprint: <sprint name> | <sprint working days> working days x 0.8 = <effective days> effective days per developer | <total items> items | ~<total estimated days> days of work | ~<FTE> full-time developers
    ```
 
-   **FTE calculation**: Assume a 1-month sprint with developers loaded at 80%. That gives 20 working days x 0.8 = 16 effective days per developer. Divide total estimated days by 16 and round to one decimal. Example: 106 days / 16 = ~6.6 full-time developers.
+   **Capacity**: `sprint working days` = Mon-Fri within `[sprint start, sprint end]` from Step 1. `effective days` = that count x 0.8 (developers are loaded at 80%). **FTE** = total estimated days / effective days, rounded to one decimal. Example: a 10-working-day sprint gives 8 effective days, so 53 days of work = ~6.6 full-time developers.
 
-4. After the stats line, add a **per-person load breakdown** table. Sum the estimated days for all items assigned to each person and compare against the 16 effective days capacity:
+   If the sprint dates could not be resolved, fall back to 16 effective days and say so in the stats line: `... | 16 effective days per developer (sprint dates unavailable, 1-month sprint assumed) | ...`.
+
+4. After the stats line, add a **per-person load breakdown** table. Sum the estimated days for all items assigned to each person and compare against the effective days capacity (the example below uses 16):
 
    ```text
    | Assignee | Est. Days | Load | Status |
@@ -230,7 +234,7 @@ Use the Jira item status (e.g., "In Code Review", "In Progress", "Done") and des
    | Unassigned | 8.0     | -    | -      |
    ```
 
-   **Load calculation**: `(estimated days / 16) x 100`, rounded to nearest percent.
+   **Load calculation**: `(estimated days / effective days) x 100`, rounded to nearest percent — the same `effective days` used for the FTE line, never a hardcoded 16.
 
    **Status icons**:
    - `OK` (70%-100% load) — properly loaded


### PR DESCRIPTION
# Summary

Fixes finding **PR-f728e4** (high) in `skills/sprint-summary/SKILL.md`.

Step 7 hardcoded the sprint capacity: "Assume a 1-month sprint with developers loaded at 80%. That gives 20 working days x 0.8 = 16 effective days per developer", and used that same 16 as the denominator of both the FTE line and every row of the per-person load table. Step 1 only fetched `--columns ID,NAME`, so the sprint's real start and end dates were never read and the assumption was never checked.

Failing condition: a two-week sprint (10 working days, ~8 effective days). A person holding 8.0 estimated days is at 100% capacity, but the table printed `50%` and labelled them `UNDER`, and the FTE line reported half the real headcount need. The load table is what a reader acts on to rebalance work, so it said the opposite of the truth.

Changes:

- Step 1 now fetches `--columns ID,NAME,START,END` and records the sprint bounds explicitly, noting that Step 7 derives capacity from them.
- Step 7 defines `sprint working days` = Mon-Fri within `[sprint start, sprint end]` and `effective days` = that count x 0.8. The 80% loading factor is kept as-is — it is a domain fact, not something derivable.
- The stats line now states the resolved sprint length and effective days, so a reader can check the arithmetic.
- The load calculation uses `effective days`, not a hardcoded 16.
- 16 survives only as the labelled fallback when the sprint dates cannot be resolved, and the stats line must say so.

No Important Rule restated the hardcoded 16, so none needed changing (and adding a duplicate capacity rule there would just be a second copy to drift). Step 5 was left untouched per the finding.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: This repo ships Markdown skill prompts, not runnable code; there is no test harness for prompt text. Verified with `npx markdownlint-cli2 skills/sprint-summary/SKILL.md` (0 issues).
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The sibling `weekly-dev-report` skill reads the sprint bounds via a `curl` call to `/rest/agile/1.0/sprint/<ID>`. This PR gets the same data from the `jira` CLI columns `START,END` instead, which `weekly-dev-report` Step 1 already uses — that keeps `sprint-summary`'s `allowed-tools` unchanged rather than granting it `Bash(curl:*)`.
