### PR TITLE
Document setup for the unbundled PayPal and Figma MCP servers

### DIFF
--- a/skills/paypal/SKILL.md
+++ b/skills/paypal/SKILL.md
@@ -8,9 +8,24 @@ allowed-tools: Bash(curl:*), Bash(jq:*), Bash(echo:*), mcp__paypal__*
 
 Manage PayPal invoices, payments, and disputes.
 
+## Setup
+
+The PayPal MCP server is **not bundled** in the plugin's `.mcp.json` (it would
+always-load for every project). Register it **per folder** with `claude mcp add`,
+which defaults to local scope:
+
+```bash
+claude mcp add --transport http paypal https://mcp.paypal.com/mcp
+```
+
+Use `https://mcp.sandbox.paypal.com/mcp` for the sandbox environment. Both endpoints
+authenticate over OAuth — run `/mcp`, select `paypal`, and approve access on first
+use. There is no token environment variable. PayPal's MCP documentation:
+<https://developer.paypal.com/ai-tools/mcp-server>.
+
 ## MCP Tools (no CLI fallback)
 
-Use MCP tools (`mcp__paypal__*`) for all PayPal operations. **There is no PayPal CLI.** If MCP tools are not available, inform the user and stop.
+Use MCP tools (`mcp__paypal__*`) for all PayPal operations. **There is no PayPal CLI.** If MCP tools are not available, point the user at the `claude mcp add` command above and stop.
 
 | Operation | MCP Tool |
 | --- | --- |
@@ -32,4 +47,4 @@ Use MCP tools (`mcp__paypal__*`) for all PayPal operations. **There is no PayPal
 - **Never create invoices or send payments without user confirmation**
 - **Format currency properly** — Display amounts with proper decimal places and currency codes
 - **Mask sensitive data** — Do not display full account numbers or personal details
-- **MCP required** — This skill cannot function without PayPal MCP access. If unavailable, inform the user.
+- **MCP required** — This skill cannot function without PayPal MCP access. If unavailable, point the user at the Setup section and stop.

--- a/skills/review-design/SKILL.md
+++ b/skills/review-design/SKILL.md
@@ -8,9 +8,22 @@ allowed-tools: Bash(git:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut
 
 Compare UI code against Figma designs to identify discrepancies in layout, styling, spacing, typography, colors, and component usage. Works for Android, iOS, and web platforms.
 
+## Setup
+
+The Figma MCP server is **not bundled** in the plugin's `.mcp.json` (it would
+always-load for every project). Register it **per folder** with `claude mcp add`,
+which defaults to local scope:
+
+```bash
+claude mcp add --transport http figma https://mcp.figma.com/mcp
+```
+
+This is Figma's hosted endpoint. Authentication is OAuth — run `/mcp`, select
+`figma`, and approve access on first use. There is no token environment variable.
+
 ## MCP Tools with Fallbacks
 
-This skill requires the Figma MCP server for design context. If Figma MCP is unavailable (not authenticated, tool not found), inform the user and stop — this skill cannot function without Figma access.
+This skill requires the Figma MCP server for design context. If Figma MCP is unavailable (not authenticated, tool not found), point the user at the `claude mcp add` command above and stop — this skill cannot function without Figma access.
 
 | Operation | MCP Tool |
 | --- | --- |
@@ -216,4 +229,4 @@ After all fixes, run the linters skill:
 4. **Check both directions** — Flag code that doesn't match design AND design system components that exist but aren't used
 5. **Ask before modifying** — Always show the report and get user approval before changing code
 6. **Run linters after changes** — Always run `/co-dev:run-linters` after modifying code
-7. **Figma MCP is required** — If Figma tools are unavailable, inform the user and stop. This skill cannot function without Figma access.
+7. **Figma MCP is required** — If Figma tools are unavailable, point the user at the Setup section and stop. This skill cannot function without Figma access.


### PR DESCRIPTION
# Summary

Fixes finding **PR-901721** (high) from the prompt review of the `co-dev` plugin.

**Failing condition:** on a clean install, `.mcp.json` bundles 13 servers (github, fetch, context7, playwright, chrome-devtools, postgres, mysql, mongodb, redis, aws, appstore, playstore, gcloud) and bundles neither `paypal` nor `figma`. `skills/paypal/SKILL.md` said "There is no PayPal CLI. If MCP tools are not available, inform the user and stop", and `skills/review-design/SKILL.md` said "this skill cannot function without Figma access" (repeated as rule 7). Neither told the user how to obtain the server, so both skills hit their own stop instruction and produce nothing — while `.claude-plugin/plugin.json` advertises "payments (PayPal)" and "design (Figma)" as capabilities.

**Change:** adds a short `## Setup` section to each of the two skill files, mirroring the shape already used for the deliberately-unbundled monday server (`skills/monday/SKILL.md` → "Authentication"): state that the server is not bundled and why, give the concrete `claude mcp add` command, name the credential, and keep the existing "inform the user and stop" as the fallback — now pointing at the command instead of dead-ending.

- PayPal: `claude mcp add --transport http paypal https://mcp.paypal.com/mcp` (sandbox: `https://mcp.sandbox.paypal.com/mcp`), OAuth on first use, no token env var, linked to <https://developer.paypal.com/ai-tools/mcp-server>.
- Figma: `claude mcp add --transport http figma https://mcp.figma.com/mcp`, OAuth on first use, no token env var.

**Endpoints were verified, not guessed.** PayPal's published quickstart still documents `/sse` and `/http` path suffixes with a `mcp-remote` + Bearer-header config; that is stale. A direct `initialize` POST returns `404` for `https://mcp.paypal.com/http` and `401` with `WWW-Authenticate: Bearer realm="OAuth", resource_metadata="https://mcp.paypal.com/.well-known/oauth-protected-resource"` for `https://mcp.paypal.com/mcp` (same for the sandbox host), so `/mcp` over HTTP transport with OAuth is the live contract. `https://mcp.paypal.com` redirects to `https://developer.paypal.com/ai-tools/mcp-server`. The Figma endpoint and command are as documented by Figma's developer docs.

**Alternative not taken (maintainer's call):** these two servers could instead be added to `.mcp.json`. That was deliberately rejected here because bundling makes a server always-load for every project — exactly the reason `skills/monday/SKILL.md` gives for not bundling monday. If you would rather bundle them, this PR is the wrong shape and should be replaced. No change was made to `.mcp.json` or `.claude-plugin/plugin.json`.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts, not runnable code; verification was `npx markdownlint-cli2` on both files (0 issues) plus live `initialize` probes against the PayPal and sandbox MCP endpoints to confirm the documented paths.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

Kept the sections deliberately short. The monday precedent carries an extra explanatory block about why the hosted endpoint is preferred over the local package (a native-addon build failure); there is no equivalent domain fact to record for PayPal or Figma, so the sections pin only what the model cannot derive — that the server is unbundled, the exact endpoint, and the auth mechanism — and leave out procedure.
