### PR TITLE
Reconcile the optional coverage run with the mandatory 80/80 floor

### DIFF
--- a/skills/write-tests/SKILL.md
+++ b/skills/write-tests/SKILL.md
@@ -34,7 +34,7 @@ Detect per target directory (monorepos may mix stacks — resolve the stack of t
 | `Gemfile` / `*.gemspec` | Ruby | `grep rspec Gemfile*` → **RSpec** (specs in `spec/`); else **Minitest/Test::Unit** (`test/`). Feature/system → **Capybara**. Fixtures → **FactoryBot** if in the Gemfile. |
 | `composer.json` | PHP | `grep pestphp/pest` → **Pest**; `grep behat/behat` → **Behat** (`features/`); else **PHPUnit**. Laravel → run via `php artisan test`. Mocks → **Mockery**. |
 | `pyproject.toml` / `requirements*.txt` / `setup.py` | Python | `grep -ri pytest` → **pytest** (`tests/`); else **unittest**. Mocks → `unittest.mock`; fixtures → `factory_boy` if present; property → `hypothesis` if present. |
-| `package.json` | JS/TS | `grep '"vitest"'` → **Vitest**; `grep '"jest"'` → **Jest**; `grep react-native` → **Jest**. E2E → **Playwright** (`grep '@playwright')` else Cypress if present. Component → Testing-Library. |
+| `package.json` | JS/TS | `grep '"vitest"'` → **Vitest**; `grep '"jest"'` → **Jest**; `grep react-native` → **Jest**. E2E → **Playwright** (`grep '@playwright'`) else Cypress if present. Component → Testing-Library. |
 | `*.csproj` / `*.sln` | C#/.NET | `grep -ri xunit` → **xUnit**; `grep -ri nunit` → **NUnit**; `grep -ri mstest` → **MSTest**. Assertions → FluentAssertions if referenced; mocks → Moq/NSubstitute. |
 | `Package.swift` / `*.xcodeproj` / `*.xcworkspace` | Swift | `grep -rl "import Testing"` → **Swift Testing** for unit; else **XCTest**. UI → **XCUITest** (always XCTest). |
 | `build.gradle(.kts)` / `settings.gradle` | Kotlin/Java | `grep -ri kotest` → **Kotest**; else **JUnit 5** (or JUnit4 if that's what's wired). Mocks → **MockK** (Kotlin) / Mockito (Java). Android UI → `composeTestRule` (Compose) or **Espresso** (Views). Flows → Turbine. |
@@ -108,7 +108,7 @@ For a bug fix, write the regression test **first**, confirm it fails against the
 
 ## Step 5: Run and iterate to green
 
-Run the suite (narrowly — just the new/affected tests first), read failures, fix, repeat until green. Then run coverage if quick.
+Run the suite (narrowly — just the new/affected tests first), read failures, fix, repeat until green. Then measure coverage — Step 6 is mandatory; only its scope is negotiable, so run it on the changed files first.
 
 | Language | Run (narrow → full) | Coverage |
 | --- | --- | --- |
@@ -118,7 +118,7 @@ Run the suite (narrowly — just the new/affected tests first), read failures, f
 | PHP (PHPUnit) | `./vendor/bin/phpunit --filter Name` → `php artisan test` | `--coverage-text` |
 | PHP (Behat) | `./vendor/bin/behat features/x.feature` | n/a |
 | Python (pytest) | `pytest path::test_name` → `pytest` | `pytest --cov=pkg` |
-| Python (unittest) | `python -m unittest module.Class.test` | `coverage run -m pytest && coverage report` |
+| Python (unittest) | `python -m unittest module.Class.test` | `coverage run -m unittest discover && coverage report` |
 | JS/TS (Vitest) | `npx vitest run path` → `npx vitest run` | `npx vitest run --coverage` |
 | JS/TS (Jest) | `npx jest path -t "name"` → `npx jest` | `npx jest --coverage` |
 | JS/TS (Playwright) | `npx playwright test path` | `--reporter=html` |


### PR DESCRIPTION
## Summary

`write-tests` told Claude two different things about coverage. Step 5 ended with "Then run coverage if quick", offering an opt-out, while Step 6 makes coverage mandatory with a hard line-and-branch floor of 80/80 and a stated resolution precedence, Step 7 requires reporting the actual percentages, and the Important Rules restate the floor as binding. A run that read Step 5 and judged coverage "not quick" would skip the gate and then have nothing real to report in Step 7. Step 5 also handed the Python (unittest) path a pytest command, which fails outright in a unittest-only repo, and the `package.json` detection row had a transposed backtick and paren.

**Key changes:**

- `skills/write-tests/SKILL.md` Step 5: replaced "Then run coverage if quick" with a statement that Step 6 is mandatory and only its scope is negotiable (run it on the changed files first), matching the 80/80 gate in Step 6, the reporting duty in Step 7, and the Important Rules.
- `skills/write-tests/SKILL.md` Step 5 run table: fixed the Python (unittest) coverage command from `coverage run -m pytest && coverage report` to `coverage run -m unittest discover && coverage report`, so it no longer requires pytest in a unittest-only repo.
- `skills/write-tests/SKILL.md` Step 1 detection table: fixed the transposed delimiters in the `package.json` row so the backtick closes before the paren, with no change in meaning.

Step 6's resolution precedence, its per-language coverage caveats, the greenfield framework matrix, the per-directory resolution rule, and the "never fake green" rules are untouched.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts and has no test harness.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
