### PR TITLE
Reconcile the --send delivery path with the declared tools

### DIFF
--- a/skills/weekly-dev-report/SKILL.md
+++ b/skills/weekly-dev-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: weekly-dev-report
 description: Generate a weekly team activity report from the active Jira sprint and linked GitHub repos, with per-member achievability ratings, stuck-ticket flags, stalled-member flags, and worklog audit. The roster mixes engineers, QA, content, and consultants; titles and language stay generic so non-engineering members aren't mislabelled. Flags sprint-goal delivery risk with a concrete, prioritized catch-up plan, and confirms each member's role (developer full-time / consultant part-time / manager-cto-ciso / tester / other) once interactively then caches it so later runs reuse it. Use when the user wants a weekly activity report, per-member Jira sprint progress audit, Jira sprint delivery-risk assessment, contributor status report, time-logged audit, or team check-in. Pulls roster from the active sprint, auto-discovers repos from Jira ticket dev-info, emails the report on --send, otherwise writes WEEKLY_REPORT.md and prints to stdout.
-allowed-tools: Bash(jira:*), Bash(gh:*), Bash(git:*), Bash(curl:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(echo:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(printenv:*), Bash(printf:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(xargs:*), Read, Write, AskUserQuestion, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__github__list_pull_requests, mcp__github__list_commits, mcp__github__get_pull_request_reviews, mcp__github__search_issues, mcp__github__get_pull_request
+allowed-tools: Bash(jira:*), Bash(gh:*), Bash(git:*), Bash(curl:*), Bash(gmail:*), Bash(gcloud:*), Bash(awk:*), Bash(basename:*), Bash(cat:*), Bash(cut:*), Bash(date:*), Bash(echo:*), Bash(grep:*), Bash(head:*), Bash(jq:*), Bash(ls:*), Bash(mkdir:*), Bash(printenv:*), Bash(printf:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(which:*), Bash(xargs:*), Read, Write, AskUserQuestion, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__github__list_pull_requests, mcp__github__list_commits, mcp__github__get_pull_request_reviews, mcp__github__search_issues, mcp__github__get_pull_request
 ---
 
 # Weekly Activity Report
@@ -781,6 +781,8 @@ If run with `--send`:
    - `gmail send` CLI if installed (`which gmail`)
    - `gcloud` SMTP relay if configured
 5. On success, print `Sent to: <list>`. On failure, leave `WEEKLY_REPORT.md` in place, print the error, and instruct the user to send manually.
+
+The Gmail MCP tools (path 1) are **discovered at runtime** and so cannot be pre-listed in `allowed-tools` — expect a one-time permission prompt the first time one is called. The `gmail` and `gcloud` CLI fallbacks are pre-granted.
 
 ## Important rules
 


### PR DESCRIPTION
# Summary

`weekly-dev-report` advertises in its own description that it "emails the report on `--send`", and Step 8 spells out a three-way delivery chain: a runtime-discovered Gmail MCP tool, then a `gmail` CLI guarded by `which gmail`, then a `gcloud` SMTP relay. The frontmatter `allowed-tools` declared none of those — no `Bash(gmail:*)`, no `Bash(gcloud:*)`, not even `Bash(which:*)` for the probe. Every fallback in the chain was undeclared, so the whole `--send` path could not execute as written.

**Key changes:**

- `skills/weekly-dev-report/SKILL.md`: add `Bash(gmail:*)`, `Bash(gcloud:*)` and `Bash(which:*)` to `allowed-tools` so the CLI and relay fallbacks (and the `which gmail` probe that gates one of them) are actually granted.
- `skills/weekly-dev-report/SKILL.md`: state in Step 8 that the Gmail MCP tools are discovered at runtime and therefore cannot be pre-listed in `allowed-tools`, so a one-time permission prompt is expected — reusing the wording `doc-tracker-coverage` already uses for its runtime-discovered Google Docs read path.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts and has no test harness
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
