### PR TITLE
Declare the date and jira commands code-review-deep actually runs

### DIFF
--- a/skills/code-review-deep/SKILL.md
+++ b/skills/code-review-deep/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-review-deep
 description: "Exhaustive multi-phase code audit using parallel agents (security, dependencies, code quality, infrastructure, tests, and more). Use when the user wants a deep or thorough code review, a comprehensive audit, a security-and-quality sweep of a repo or subsystem, or a multi-agent review that goes beyond the current diff. Optionally scoped to a path or subsystem."
-allowed-tools: Bash(git:*), Bash(gh:*), Bash(jq:*), Bash(awk:*), Bash(cat:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(ls:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, TodoWrite, Workflow, Agent, Skill, AskUserQuestion, WebSearch, WebFetch, mcp__github__*, mcp__context7__*
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(jira:*), Bash(jq:*), Bash(awk:*), Bash(cat:*), Bash(date:*), Bash(echo:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(ls:*), Bash(sed:*), Bash(sort:*), Bash(tail:*), Bash(tr:*), Bash(uniq:*), Bash(wc:*), Bash(xargs:*), Read, Write, Edit, Glob, Grep, TodoWrite, Workflow, Agent, Skill, AskUserQuestion, WebSearch, WebFetch, mcp__github__*, mcp__context7__*
 ---
 
 # Deep Code Review (Workflow-Orchestrated)
@@ -363,21 +363,14 @@ NOT executed automatically. After the report is generated, if the user asks ("cr
 
 **Summary format:** `[REPO-NAME][FINDING-ID] Brief description` (e.g., `[pnp-ios][SEC-001] Rotate hardcoded AWS credentials`).
 
-**Before creating:**
+**Dedupe.** List the existing `code-review` issues once before creating and again after, using the tracker `create-issue` resolved to (`gh repo view --json hasIssuesEnabled --jq '.hasIssuesEnabled'`):
 
-```bash
-jira issue list --label "code-review" --plain --columns key,summary
-```
+- GitHub Issues: `gh issue list --label "code-review" --state all --limit 500 --json number,title,state`
+- Jira: `jira issue list --label "code-review" --plain --columns key,summary,status`
 
 Skip any matching by BOTH repo name AND finding ID.
 
-**After creating:**
-
-```bash
-jira issue list --label "code-review" --plain --columns key,summary,status
-```
-
-Report: "Created X new issues, Y already existed, Z total issues".
+Report: "Created X new issues, Y already existed, Z total issues" — Y from the before-list, Z from the after-list.
 
 ### Labels
 


### PR DESCRIPTION
## Summary

The `code-review-deep` skill instructs two commands it never declares permission for. Step 2 (Repository Context) computes `REPO_AGE_DAYS` with `$(date +%s)`, and the Issue Creation section shells out to `jira issue list` — but `allowed-tools` granted neither `Bash(date:*)` nor `Bash(jira:*)`, so both calls hit a permission prompt (or fail outright in a non-interactive run) mid-review.

The same section also told the model to use the `create-issue` skill "because it auto-detects GitHub Issues vs Jira", then gave Jira-only dedupe commands. On a repo with GitHub Issues enabled there was no defined way to list existing `code-review` issues, so the mandated closing line "Created X new issues, Y already existed, Z total issues" had no source for Y or Z.

**Key changes:**

- `skills/code-review-deep/SKILL.md`: add `Bash(jira:*)` and `Bash(date:*)` to `allowed-tools`, matching the ordering used by the sibling issue-tracker skills (`create-issue`, `work-issue`, `verify-resolved-issues`).
- `skills/code-review-deep/SKILL.md`: give the GitHub Issues branch its own dedupe command (`gh issue list --label "code-review" --state all --limit 500 --json number,title,state`) alongside the Jira one, keyed off the `hasIssuesEnabled` detection the skill already documents, so both trackers can produce Y and Z.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts and has no test harness; the changed file was verified with `markdownlint-cli2` (0 issues)
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
