### PR TITLE
Close the LIMIT band overlap, the Redis write gaps and the lost MySQL timeout

### DIFF
--- a/skills/query-db/SKILL.md
+++ b/skills/query-db/SKILL.md
@@ -276,6 +276,7 @@ Parse what the user is asking for:
 
 ```bash
 MYSQL_PWD="$MYSQL_PASS" mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" "$MYSQL_DB" -e "
+SET SESSION MAX_EXECUTION_TIME=30000;
 SELECT DATE(created_at) as day, COUNT(*) as orders, SUM(total)/100 as revenue
 FROM orders
 WHERE created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)
@@ -288,6 +289,7 @@ LIMIT 100;"
 
 ```bash
 psql -c "
+SET statement_timeout = '30s';
 SELECT DATE(created_at) as day, COUNT(*) as orders, SUM(total)/100 as revenue
 FROM orders
 WHERE created_at >= NOW() - INTERVAL '30 days'
@@ -542,7 +544,7 @@ Before executing any query, scan for write/mutate keywords. Match these as **SQL
 **SQL (MySQL/PostgreSQL/SQLite):** `INSERT`, `UPDATE`, `DELETE`, `DROP`, `ALTER`, `TRUNCATE`, `CREATE`, `REPLACE`
 **MongoDB:** `insertOne`, `insertMany`, `updateOne`, `updateMany`, `deleteOne`, `deleteMany`, `drop`, `replaceOne`
 **Elasticsearch:** `_delete_by_query`, `_update_by_query`, `PUT` (index creation/mapping)
-**Redis:** `DEL`, `FLUSHDB`, `FLUSHALL`, `SET`, `HSET`, `LPUSH`, `SADD`, `ZADD`
+**Redis:** allowlist, not blocklist — Redis has far more write commands than read ones. Only these are read-only and may run without confirmation: `GET`, `MGET`, `GETRANGE`, `STRLEN`, `EXISTS`, `TYPE`, `TTL`, `PTTL`, `HGET`, `HMGET`, `HGETALL`, `HKEYS`, `HVALS`, `HLEN`, `HEXISTS`, `LRANGE`, `LINDEX`, `LLEN`, `SMEMBERS`, `SISMEMBER`, `SCARD`, `SINTER`, `SUNION`, `SDIFF`, `ZRANGE`, `ZREVRANGE`, `ZRANGEBYSCORE`, `ZSCORE`, `ZCARD`, `ZCOUNT`, `PFCOUNT`, `SCAN`, `HSCAN`, `SSCAN`, `ZSCAN`, `XRANGE`, `XREVRANGE`, `XLEN`, `BITCOUNT`, `GETBIT`, `JSON.GET`, `JSON.TYPE`, `DBSIZE`, `INFO`, `PING`. Treat **everything else** as a write — including `GETSET`/`GETDEL` (read-looking but destructive), `EXPIRE`/`PERSIST`, `RENAME`, `INCR`/`DECR`, `LPOP`/`RPOP`/`SPOP`, and `EVAL`/`EVALSHA`/`FCALL`/`SCRIPT` (scripts can write whatever they like). The allowlist governs the `mcp__redis__*` tools as well as `redis-cli`.
 **BigQuery:** `INSERT`, `UPDATE`, `DELETE`, `DROP`, `ALTER`, `TRUNCATE`, `CREATE`, `MERGE`
 
 **If a write operation is detected:**
@@ -560,7 +562,7 @@ Read table/collection row counts from the "Large Table Warnings" or "All Tables"
 | --- | --- |
 | < 1M rows | LIMIT optional (add if no aggregation) |
 | 1M–10M rows | Inject `LIMIT 1000`; warn user about table size |
-| > 10M rows | Inject `LIMIT 100`; require date range filter if table has a date field |
+| 10M–50M rows | Inject `LIMIT 100`; require date range filter if table has a date field |
 | > 50M rows | **Refuse** query without date range filter; explain why |
 
 **Exception:** Do NOT inject LIMIT on aggregation queries (`COUNT`, `SUM`, `AVG`, `GROUP BY`, MongoDB `$group`, ES `aggs`). Instead, add date-range filters to narrow the source data.
@@ -578,8 +580,8 @@ Prepend or append timeout settings to prevent runaway queries:
 
 | Database | Timeout Setting |
 | --- | --- |
-| MySQL | Prepend `SET SESSION MAX_EXECUTION_TIME=30000;` before the query |
-| PostgreSQL | Prepend `SET statement_timeout = '30s';` before the query |
+| MySQL | Prepend `SET SESSION MAX_EXECUTION_TIME=30000;` to the query, inside the same `-e` string (see Step 6) — a separate `mysql` invocation gets a separate session and the timeout is lost |
+| PostgreSQL | Prepend `SET statement_timeout = '30s';` to the query, inside the same `-c` string (see Step 6) — same session requirement as MySQL |
 | SQLite | No server-side timeout; SQLite is file-based and typically fast. Use `LIMIT` to constrain large result sets |
 | MongoDB | Append `.maxTimeMS(30000)` to `find()` or `aggregate()` calls |
 | Elasticsearch | Add `"timeout": "30s"` to the query body |


### PR DESCRIPTION
# Summary

Three guardrails in the `query-db` skill could be satisfied while still doing the unsafe thing. A 60M-row table matched two different LIMIT-injection rows with no precedence rule, so it could legitimately be handled either way. The Redis write-blocklist named eight commands and missed every other mutating family, including scripting, so the read-only guarantee had holes reachable through both `Bash(redis-cli:*)` and the `mcp__redis__*` wildcard. And the MySQL/PostgreSQL query timeouts were described as "prepend before the query" while no invocation template showed the statement inside `-e`/`-c`, so a second invocation would open a new session and silently drop the timeout.

**Key changes:**

- `skills/query-db/SKILL.md` — LIMIT band `> 10M rows` narrowed to `10M-50M rows` so the bands no longer overlap with the `> 50M rows` refuse rule
- `skills/query-db/SKILL.md` — Redis write detection switched from an ever-growing blocklist to a read-command allowlist; everything not listed is a write, explicitly including `GETSET`/`GETDEL`, `EXPIRE`/`PERSIST`, `RENAME`, `INCR`/`DECR`, `LPOP`/`RPOP`/`SPOP` and `EVAL`/`EVALSHA`/`FCALL`/`SCRIPT`, and the allowlist is stated to govern the `mcp__redis__*` tools as well as `redis-cli`
- `skills/query-db/SKILL.md` — Step 6 canonical MySQL and PostgreSQL invocations now carry `SET SESSION MAX_EXECUTION_TIME=30000;` / `SET statement_timeout = '30s';` inside the `-e`/`-c` string, and the Query Timeout table says why a separate invocation loses the setting

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts and has no test harness
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
