### PR TITLE
Settle who authors the audit comment and fix the MCP invocation syntax

### DIFF
--- a/skills/verify-resolved-issues/SKILL.md
+++ b/skills/verify-resolved-issues/SKILL.md
@@ -191,25 +191,23 @@ Decide one of four outcomes: **VERIFIED** (fix matches issue + present in codeba
 
 ### Step 5-G: Act
 
-Compose comments using the templates below. In `--dry-run`, print them to stdout (one block per issue) with the planned action and stop.
+Post the workflow's `comment_markdown` verbatim — don't rewrite it. In `--dry-run`, print it to stdout (one block per issue) with the planned action and stop.
 
 **On VERIFIED** — close the issue:
 
+- MCP preferred: `mcp__github__add_issue_comment` with `body` = `comment_markdown`, then `mcp__github__update_issue` with `state: "closed"` and `state_reason: "completed"`.
+- CLI fallback:
+
 ```bash
-# MCP preferred
-mcp__github__add_issue_comment ...
-mcp__github__update_issue --state closed --state_reason completed
-# CLI fallback
 gh issue close <NUM> --comment-from-file comment.md --reason completed
 ```
 
 **On NOT_VERIFIED** — comment, ensure the issue is open, reassign to the resolver:
 
+- MCP preferred: `mcp__github__add_issue_comment` with `body` = `comment_markdown`, then `mcp__github__update_issue` with `assignees: ["<resolver-login>"]`.
+- CLI fallback:
+
 ```bash
-# MCP preferred
-mcp__github__add_issue_comment ...
-mcp__github__update_issue --assignees '["<resolver-login>"]'
-# CLI fallback
 gh issue comment <NUM> --body-file comment.md
 gh issue edit <NUM> --add-assignee <resolver-login>
 # also remove a misleading "fixed"/"resolved" label, if present
@@ -276,11 +274,9 @@ project = $PROJECT
 ORDER BY statusCategoryChangedDate DESC
 ```
 
-Run via JQL search (paginate past 100):
+Run via JQL search (paginate past 100) — `mcp__atlassian__searchJiraIssuesUsingJql` with the query above as `jql`, or the CLI fallback:
 
 ```bash
-mcp__atlassian__searchJiraIssuesUsingJql ...
-# or
 jira issue list -q "<JQL>" --plain --no-headers --no-truncate \
   --columns KEY,STATUS,ASSIGNEE,SUMMARY --paginate
 ```
@@ -360,6 +356,8 @@ In `--dry-run`, print the planned action per issue and stop.
 ---
 
 ## Comment Templates
+
+> **Delegated to the workflow.** `verify-resolved-issues.workflow.js` drafts every comment and returns it as `comment_markdown`, ready to post verbatim — you never fill a template yourself. The templates reproduced below are reference only, kept so a reader can see what the workflow's agents produce. The workflow file is authoritative — edits here change nothing at runtime.
 
 The comments you post are the load-bearing artifact of this skill. A vague comment ("looks fixed!", "doesn't seem fixed") is worse than no comment, because it pollutes the audit trail. Be concrete: name files, line numbers, commits, and tests.
 


### PR DESCRIPTION
## Summary

`skills/verify-resolved-issues/SKILL.md` gave two contradictory answers to "who writes the audit comment". The "Parallel verification via workflow" section says the templates and comment drafting live in `verify-resolved-issues.workflow.js`, that `comment_markdown` is "the fully-filled, correctly-languaged comment to post verbatim", and "Do not re-verify - trust the workflow's verdict" — but Step 5-G then said "Compose comments using the templates below", above a full second copy of both templates that has already drifted from the workflow's versions ("appears to have been removed by" vs "appears removed by"; two extra "one bullet per ..." lines). A reader could reasonably re-draft the comment from the stale copy instead of posting the one the workflow handed back.

Separately, three MCP tools were shown inside bash fences with CLI-style flags (`mcp__github__update_issue --state closed --state_reason completed`, `mcp__github__add_issue_comment ...`, `mcp__atlassian__searchJiraIssuesUsingJql ...`). MCP tools take structured arguments, not shell flags, and in a bash fence they read as runnable commands.

**Key changes:**

- Step 5-G now says to post the workflow's `comment_markdown` verbatim instead of composing from the templates.
- The "Comment Templates" section carries an explicit delegation note in the same form Step 4-G already uses for its checklist: the workflow drafts every comment, the copies below are reference only, and the workflow file is authoritative — edits here change nothing at runtime.
- The GitHub write steps name `mcp__github__add_issue_comment` / `mcp__github__update_issue` with their named parameters (`state`, `state_reason`, `assignees`) as prose bullets; the `gh` fallbacks stay in bash.
- The Jira candidate search names `mcp__atlassian__searchJiraIssuesUsingJql` with the JQL passed as `jql` in prose; the `jira issue list` fallback stays in bash.
- No change to the four-outcome rules, `SKIP_NEEDS_MANUAL` guidance, the language rule, or the narrow-scope defaults.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts and has no test harness
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
