### PR TITLE
Track all nine phases and stop the per-package SOUP grep from exhausting context

### DIFF
--- a/skills/review-architecture/SKILL.md
+++ b/skills/review-architecture/SKILL.md
@@ -22,6 +22,7 @@ Use `TodoWrite` to track each phase below. Mark `in_progress` on entry, `complet
 6. Existing doc structure validated
 7. Report generated
 8. Doc written/updated (if approved)
+9. Linters run
 
 **Evidence rule:** Every check must record (a) what the doc claims, (b) what the code shows (file:function), (c) MATCH / MISMATCH / MISSING. Bare "PASS" without code evidence is invalid.
 
@@ -178,7 +179,7 @@ Run only the sub-phases matching the project type. Record exact counts and file:
 - Python: `find . -name "__init__.py" -not -path "*/venv/*" -not -path "*/.venv/*"` → take parent dirs.
 - Node/TypeScript: `package.json` `main`/`exports`; `src/`, `lib/`.
 - Go: parent dirs of `*.go` (excluding `vendor/`).
-- Rust: parent dirs of `Cargo.toml`.
+- Rust: crate roots (`src/lib.rs`, `src/main.rs`) plus the `mod` declarations they pull in — each `src/**/*.rs` and `mod.rs` is a module. `Cargo.toml` marks crates, not modules.
 
 For each module, extract docstring (head of `__init__.py`), exported symbols (`^class`, `^def`, `export`, `func [A-Z]`).
 
@@ -193,9 +194,15 @@ cat docs/soup.json soup.json 2>/dev/null
 
 Extract dependency lists from lock files: `poetry.lock`, `requirements.txt`, `package.json`, `Gemfile.lock`, `go.mod`, `Cargo.lock`.
 
+Collect every import/require/use site in ONE repo-wide pass, then match those sites against the package list in memory. Never grep once per package — that exhausts context before the review finishes.
+
+```bash
+grep -rnE "^[[:space:]]*(import|from|use|require)[[:space:](]" --include="*.py" --include="*.js" --include="*.ts" --include="*.rb" --include="*.go" --include="*.rs" . | grep -v node_modules | grep -v venv
+```
+
 For **every** package in `soup.json` (not a sample), validate three fields:
 
-1. **Requirements** — does the stated purpose match how the package is actually used? Use `grep -rn "require.*{pkg}\|import.*{pkg}\|from {pkg}\|use {pkg}" --include="*.py" --include="*.js" --include="*.ts" --include="*.rb" --include="*.go" --include="*.rs" .` to find actual usage, then compare:
+1. **Requirements** — does the stated purpose match the usage sites collected above?
 
    - BAD: AWS SDK with Requirements "image processing"
    - GOOD: AWS SDK with Requirements "Cloud infrastructure API access"


### PR DESCRIPTION
## Summary

`skills/review-architecture/SKILL.md` had three defects that made the review skip a mandatory phase, die mid-run on real repos, and misreport Rust module structure.

The "Required phases" list drives the TodoWrite plan, but it enumerated only 8 entries while the body defines 9 `## Phase N` headings — "Phase 9: Run Linters" had no entry, so the linter phase was systematically dropped from every plan even though Important Rule 11 makes it mandatory.

Phase 5.A.3 required validating **every** package in `soup.json` and prescribed a `grep` interpolating `{pkg}` — one tool call per package. On a repo with a few hundred lock-file entries that exhausts context before Phase 7 and the review dies without producing a report. The completeness requirement is a real contract and is unchanged; only the mechanism is now batched.

Phase 5.A.2 told the reviewer to find Rust modules by taking the parent dirs of `Cargo.toml`. That finds workspace crates, not modules — in a single-crate repo it reports one software unit for the entire codebase.

**Key changes:**

- Added `9. Linters run` to the Required phases list so the tracked list matches the nine defined phase headings.
- Replaced the per-package SOUP grep with a single repo-wide pass that collects all import/require/use sites, then matches them against the package list in memory; the "every package (not a sample)" requirement is kept verbatim.
- Corrected the Rust module-discovery recipe to crate roots (`src/lib.rs`, `src/main.rs`) plus the `mod` declarations they pull in, noting that `Cargo.toml` marks crates, not modules.

Not changed: the required H2 section lists for either project type, the SOUP field semantics, and the report template.

Note for a follow-up: `skills/review-user-guide/SKILL.md` has the identical off-by-one (6 tracked phases vs 7 defined, also dropping "Run Linters"). It is out of scope for this PR.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts and has no test harness
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
