### PR TITLE
Re-derive branch names per command instead of relying on shell state

### DIFF
--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -32,6 +32,8 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 echo "Default: $DEFAULT_BRANCH | Current: $CURRENT_BRANCH"
 ```
 
+**Every Bash call runs in a fresh shell, so these two values do not persist.** In every later snippet that references `$DEFAULT_BRANCH` or `$CURRENT_BRANCH`, prepend the two assignments above so they are re-derived in that same call. Without that they expand empty — `git push -u origin ""` and `git checkout ""` fail, and `git diff ...HEAD` silently reports no changes.
+
 **Step 1.2:** Get file change summary (THIS IS CRITICAL - you must see ALL files):
 
 ```bash
@@ -128,7 +130,8 @@ Prefer `mcp__github__create_pull_request` when the GitHub MCP server is availabl
 
 ```bash
 PR_URL=$(gh pr create --base "$DEFAULT_BRANCH" --head "$CURRENT_BRANCH" --title "<PR title from Step 2>" --body "<PR body from Step 2>")
-open "$PR_URL"
+echo "$PR_URL"
+open "$PR_URL" 2>/dev/null || true   # macOS only — a no-op elsewhere, never fatal
 ```
 
 If a PR already exists for `$CURRENT_BRANCH` (e.g., the caller already opened it), `gh pr create` will fail — treat that as success and continue to Step 7.


### PR DESCRIPTION
## Summary

`create-pr`'s Step 1.1 assigns `DEFAULT_BRANCH` and `CURRENT_BRANCH` in one fenced bash block, but every consumer sits in a different fenced block — Step 1.2/1.3 (`git diff ${DEFAULT_BRANCH}...HEAD`), Step 5 (`git push -u origin "$CURRENT_BRANCH"`), Step 6 (`gh pr create --base/--head`), Step 7 (`git rev-parse`) and Step 8 (`git checkout "$DEFAULT_BRANCH"`). Each fenced block is a separate Bash tool call and shell state does not persist across calls, so those variables expand empty. Combined with Step 1's "YOU MUST EXECUTE THESE COMMANDS IN ORDER", the skill pushes toward exactly the literal execution that breaks: `git checkout ""` fails with exit 128, and `git diff ...HEAD --stat` is worse — it silently prints nothing and exits 0, so the PR summary would be generated from an empty diff.

This adds one line under Step 1.1 stating that each Bash call is a fresh shell and the two assignments must be re-derived in any call that references them. That single statement governs all six downstream sites, including Step 7, which is left untouched. Step 1.1 itself is kept, since printing the two values is useful orientation.

Separately, Step 6 ran `open "$PR_URL"` unguarded; `open` is macOS-only and aborts the block on Linux. It is now non-fatal, with the URL echoed so it stays visible where `open` is a no-op.

**Key changes:**

- `skills/create-pr/SKILL.md`: state under Step 1.1 that each Bash call is a fresh shell and `DEFAULT_BRANCH`/`CURRENT_BRANCH` must be re-derived in the same call that uses them
- `skills/create-pr/SKILL.md`: make Step 6's `open "$PR_URL"` non-fatal on non-macOS and echo the PR URL

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts and has no test harness
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
