### PR TITLE
Verify resumed migrations instead of silently reporting zero mismatches

### DIFF
--- a/skills/migrate-code/migrate-code.workflow.js
+++ b/skills/migrate-code/migrate-code.workflow.js
@@ -61,6 +61,7 @@ const testCmd = input.testCmd || ''
 const repoRoot = input.repoRoot || '.'
 const maxCompileRounds = Number.isFinite(input.maxCompileRounds) ? input.maxCompileRounds : 4
 const maxTestRounds = Number.isFinite(input.maxTestRounds) ? input.maxTestRounds : 3
+const maxVerifyFiles = Number.isFinite(input.maxVerifyFiles) ? input.maxVerifyFiles : 24
 
 // Right-sizing: bulk translation on a smaller model; authorship + all judgement
 // on the strong model. The skill may override via args.translateModel etc.
@@ -422,7 +423,17 @@ const translated = await pipeline(
       schema: TRANSLATE_SCHEMA,
       model: REVIEW_MODEL,
       effort: 'medium',
-    }).then(rev => rev ? { ...port, ...rev, source_file: f.source_file, target_file: f.target_file, status: port.status } : port)
+    }).then(rev => rev ? {
+      ...port,
+      ...rev,
+      source_file: f.source_file,
+      target_file: f.target_file,
+      status: port.status,
+      // The reviewer's own counts never erase the porter's: `todo_count` is the risk
+      // signal Verify ranks on, and both agents may report rule gaps.
+      todo_count: Math.max(port.todo_count || 0, rev.todo_count || 0),
+      rule_gaps: [...(port.rule_gaps || []), ...(rev.rule_gaps || [])],
+    } : port)
   },
 )
 
@@ -548,13 +559,16 @@ if (!testCmd) {
 // Adversarial behavioral check on the highest-risk ported files. Two reviewers
 // per file; if they disagree on the verdict, a third breaks the tie (2-of-3).
 phase('Verify')
+// 'skipped-exists' files count as candidates: they are ported code that this run
+// never behaviorally checked, and on a RESUMED run they are every file — excluding
+// them would verify nothing while still reporting zero mismatches.
 const verifyCandidates = ported
-  .filter(p => p.status === 'ported')
+  .filter(p => p.status === 'ported' || p.status === 'skipped-exists')
   .sort((a, b) => (b.todo_count || 0) - (a.todo_count || 0))
-const verifyTargets = verifyCandidates.slice(0, Math.min(input.maxVerifyFiles || 24, ported.length))
+const verifyTargets = verifyCandidates.slice(0, maxVerifyFiles)
 const droppedVerifyFiles = verifyCandidates.length - verifyTargets.length
-log('Adversarially verifying ' + verifyTargets.length + ' highest-risk ported file(s) for behavioral fidelity.')
-if (droppedVerifyFiles > 0) log('Capped at ' + verifyTargets.length + ' of ' + verifyCandidates.length + ' ported file(s) — ranked by TODO(migrate) marker count, so the ' + droppedVerifyFiles + ' with the fewest markers are never verified.')
+log('Adversarially verifying ' + verifyTargets.length + ' of ' + verifyCandidates.length + ' ported file(s) for behavioral fidelity.')
+if (droppedVerifyFiles > 0) log('Capped at ' + verifyTargets.length + ' of ' + verifyCandidates.length + ' ported file(s) — ranked by TODO(migrate) marker count (unknown, so ranked last, for files skipped as already-ported), so the ' + droppedVerifyFiles + ' lowest-ranked are never verified.')
 
 function verifyPrompt(p, lens) {
   return [
@@ -620,13 +634,17 @@ return {
     blocked: blocked.length,
     needs_human: needsHuman.length,
     todos: totalTodos,
-    behavioral_mismatches: behavioralMismatches.length,
+    verified: verifyResults.length,
+    // null — NEVER 0 — when nothing was verified: a zero here reads as "verified
+    // clean" when no file was ever checked.
+    behavioral_mismatches: verifyResults.length ? behavioralMismatches.length : null,
   },
   // What the per-phase caps dropped, so the report can say so instead of implying full coverage.
   capped: {
     error_groups: droppedErrorGroups,
     test_failures: droppedTestFailures,
     verify_files: droppedVerifyFiles,
+    unverified_files: verifyCandidates.length - verifyResults.length,
   },
   translated: ported.map(p => ({
     source_file: p.source_file, target_file: p.target_file, status: p.status,


### PR DESCRIPTION
# Summary

On a resumed migration the Translate stage returns `status: "skipped-exists"` for every file whose target already exists — which is every file. The Verify phase built its candidate list with `.filter(p => p.status === "ported")`, so a resumed run adversarially verified nothing yet still returned `ok: true`, `behavioral_mismatches: 0`, an empty `verify` array, and `capped.verify_files: 0`. The skill renders that as "verified clean" when no file was ever checked. This makes the resumed path actually verify, and makes a zero mismatch count unreachable when nothing was verified.

**Key changes:**

- Verify candidates now include `skipped-exists` files — ported code this run never behaviorally checked — so a resumed migration is verified instead of silently skipped.
- `counts.behavioral_mismatches` is `null`, never `0`, when zero files were verified, and `counts.verified` reports how many files were actually checked.
- `capped.unverified_files` discloses ported files that got no verification, alongside the existing `capped` counts.
- `maxVerifyFiles` is guarded with `Number.isFinite` at the top of the file, like `maxCompileRounds` and `maxTestRounds`; a non-numeric value previously reached `slice()` as `NaN` and silently verified nothing.
- The verify cap is applied against the candidate population instead of the wider `ported` list that `droppedVerifyFiles` is computed from.
- In the Translate pipeline, a reviewer's `todo_count` and `rule_gaps` no longer overwrite the porter's via `{ ...port, ...rev }` — `todo_count` is the field Verify ranks candidates on, and both agents can report rule gaps.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: this repo ships Markdown skill prompts and workflow scripts with no test harness
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
