### PR TITLE
Drop the HTTPS transport workaround now that SSH multiplexing handles it

### DIFF
--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -129,13 +129,9 @@ Run the project's existing test suite before pushing. A red CI run that a local 
 
 ## Step 5: Push the Branch
 
-**When `git remote get-url origin` starts with `git@` or `ssh://`, push over HTTPS with the gh credential helper instead of SSH:**
-
 ```bash
-git -c credential.helper='!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' push -u origin "$CURRENT_BRANCH"
+git push -u origin "$CURRENT_BRANCH"
 ```
-
-For an HTTPS remote, plain `git push -u origin "$CURRENT_BRANCH"` is fine (the `insteadOf` rewrite simply never matches, so the flags are also harmless to leave on). The reason for avoiding SSH: git opens a fresh SSH session per network command, and IDS routers (Firewalla and similar) read repeated short-lived SSH sessions to github.com as a password-guessing attempt and raise an alarm on the machine running this skill. HTTPS authenticates over TLS with the same `GITHUB_TOKEN` direnv already loaded — no SSH session, no alarm. Both `-c` flags are per-invocation; nothing persistent changes in the repo or global git config. A non-GitHub SSH remote is out of scope for the rewrite — leave it on SSH.
 
 ## Step 6: Open the Pull Request
 
@@ -185,10 +181,8 @@ Leave the repo on the default branch so the user is back at a clean starting poi
 
 ```bash
 git checkout "$DEFAULT_BRANCH"
-git -c credential.helper='!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' pull --ff-only
+git pull --ff-only
 ```
-
-The `-c` flags on the pull are the same SSH-avoidance rule as Step 5, for the same reason: the pull is this skill's other network git command.
 
 **Skip this step when running inside a `git worktree`.** A branch can only be checked out by one worktree at a time, so `git checkout` will fail (or pull the branch out from under the main checkout). Detect with:
 


### PR DESCRIPTION
## Summary

Removes the HTTPS-transport workaround from `create-pr` Steps 5 and 8, restoring plain `git push` / `git pull`. The Firewalla SSH alarm it tried to address is now fixed at the machine level with SSH connection multiplexing (`ControlMaster`/`ControlPersist` for github.com), which silences the repeated-short-sessions heuristic while keeping SSH remotes — so the skill no longer needs to dictate transport. This commit was originally pushed to the PR #117 branch moments after that PR merged, so it lands here on its own.

**Key changes:**

- `skills/create-pr/SKILL.md` — Step 5 returns to `git push -u origin "$CURRENT_BRANCH"` and Step 8 to `git pull --ff-only`; the credential-helper/insteadOf flag blocks and their rationale paragraphs are deleted.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: the change deletes instruction text from a skill document; markdownlint passes on the repo config
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
