### PR TITLE
Exclude skill-generated review docs from markdownlint and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,7 +251,6 @@ modules.xml
 # Icon must end with two \r
 Icon
 
-
 # Thumbnails
 ._*
 
@@ -477,5 +476,9 @@ $RECYCLE.BIN/
 
 # END AI Assistants
 
+# Skill-generated review artifacts
 docs/code-review.md
+docs/copy-review.md
+docs/migration/
 docs/prompt-review.md
+docs/seo-audit.md

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,7 +13,16 @@ globs:
   - "!**/dist/**"
   - "!**/build/**"
   - "!**/target/**"
+  # Skill-generated review artifacts under docs/: rewritten wholesale on every run and
+  # gitignored, so lint failures there are noise. Living docs a skill creates once and then
+  # maintains (README.md, docs/architecture.md, docs/user-guide.md, docs/db.md,
+  # docs/ownership-map.md, docs/threat-model.md) stay linted. Root-level run reports
+  # (WEEKLY_REPORT.md, SPRINT.md, issue-body.md, ...) are self-deleted by their skills.
   - "!docs/code-review.md"
+  - "!docs/copy-review.md"
+  - "!docs/migration/**"
+  - "!docs/prompt-review.md"
+  - "!docs/seo-audit.md"
 config:
   default: true
   first-line-heading: false


### PR DESCRIPTION
## Summary

The review artifacts the skills write under docs/ are rewritten wholesale on every run and are never hand-maintained, so a markdownlint failure in one of them can only be resolved by regenerating the file. docs/code-review.md was already excluded on both fronts, but docs/prompt-review.md was gitignored while still being linted, and was failing the Markdown Linter job with 37 errors (MD056, MD060, MD038) on machine-written table rows. This aligns the two lists on the same set of generated review outputs.

**Key changes:**

* Exclude docs/copy-review.md (review-copy), docs/seo-audit.md (review-seo), docs/prompt-review.md and docs/migration/** (migrate-code) from the markdownlint globs in .markdownlint-cli2.yaml, alongside the existing docs/code-review.md
* Add the same paths to .gitignore, which previously listed only docs/code-review.md and docs/prompt-review.md
* Name the .gitignore comment to match the pattern github-build will manage, so this hand-added block is superseded cleanly rather than duplicated on the next build
* Record in the config comment why living docs (README.md, docs/architecture.md, docs/user-guide.md, docs/db.md, docs/ownership-map.md, docs/threat-model.md) stay linted, and why root-level run reports that the skills self-delete need no entry
* Drop a stray blank line in the macOS section of .gitignore

Verified by writing deliberately broken Markdown (bad table column count, bad list spacing) to each newly excluded path, re-running the linters, and confirming the file count dropped without new findings, then removing the test files. The linters now report 0 issues across the Markdown, YAML and GitHub Actions checks.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: linter configuration change, and this repository has no test harness; verified by running the linters directly
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
