### PR TITLE
Ignore generated review artifacts and expand the README introduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,8 +249,7 @@ modules.xml
 .LSOverride
 
 # Icon must end with two \r
-Icon
-
+Icon
 
 # Thumbnails
 ._*
@@ -466,6 +465,13 @@ $RECYCLE.BIN/
 # Claude Code
 .claude/
 
+# Claude Code skill review artifacts
+docs/code-review.md
+docs/copy-review.md
+docs/migration/
+docs/prompt-review.md
+docs/seo-audit.md
+
 # Cursor
 .cursor/
 
@@ -477,5 +483,3 @@ $RECYCLE.BIN/
 
 # END AI Assistants
 
-docs/code-review.md
-docs/prompt-review.md

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,7 +13,15 @@ globs:
   - "!**/dist/**"
   - "!**/build/**"
   - "!**/target/**"
+  # Claude Code skill review artifacts: rewritten wholesale on every run and gitignored,
+  # so a lint failure there can only be "fixed" by regenerating the file. Living docs the
+  # same skills maintain (README.md, docs/architecture.md, docs/user-guide.md, docs/db.md,
+  # docs/ownership-map.md, docs/threat-model.md) stay linted.
   - "!docs/code-review.md"
+  - "!docs/copy-review.md"
+  - "!docs/migration/**"
+  - "!docs/prompt-review.md"
+  - "!docs/seo-audit.md"
 config:
   default: true
   first-line-heading: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Claude Code plugin for development workflow automation.
 ## Table of Contents
 
 * [Introduction](#introduction)
+  * [Features](#features)
 * [Installation](#installation)
   * [Quick Start](#quick-start)
   * [Configure Remote MCPs (optional)](#configure-remote-mcps-optional)
@@ -21,7 +22,14 @@ Claude Code plugin for development workflow automation.
 
 ## Introduction
 
-This plugin provides development workflow automation for Claude Code.
+`claude-code-plugin-dev` is the source repository for **`co-dev`**, a Claude Code plugin that automates day-to-day
+development workflows. It bundles 32 skills — issue tracking, PR creation, deep code review, test generation, linting,
+documentation reviews, cloud and app-store operations, and reporting — alongside 13 language servers and 13 MCP servers
+that Claude Code loads automatically once the plugin is installed.
+
+It is aimed at engineering teams that want these workflows available in every repository without wiring up each
+integration by hand. Credentials are always read from environment variables, never stored in the plugin, so the same
+install works across multiple accounts and tenants.
 
 ### Features
 


### PR DESCRIPTION
## Summary

The Claude Code skills in this plugin write several review artifacts into `docs/` on every run (`code-review.md`, `copy-review.md`, `prompt-review.md`, `seo-audit.md`, and the `docs/migration/` tree). These files are regenerated wholesale each time, so they should neither be committed nor gated by markdownlint — a lint failure in one can only be "fixed" by regenerating the file. This PR groups them under a single ignore block in `.gitignore`, excludes them from markdownlint, and leaves the living docs the same skills maintain (README, architecture, user guide, db, ownership map, threat model) fully linted.

It also replaces the one-line README introduction with a real description of what the plugin is, who it is for, and how credentials are handled.

**Key changes:**

* `.gitignore`: collect the generated review artifacts into a labelled "Claude Code skill review artifacts" block inside the AI Assistants section, adding `docs/copy-review.md`, `docs/migration/`, and `docs/seo-audit.md`; remove the two stray entries that had been appended after the `# END AI Assistants` marker
* `.markdownlint-cli2.yaml`: exclude the same five artifact paths from linting, with a comment explaining why they are excluded and which docs deliberately remain linted
* `README.md`: expand the Introduction with the plugin's purpose, its 32 skills, 13 language servers and 13 MCP servers, its target audience, and the environment-variable credential model; add the `Features` entry to the Table of Contents

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: configuration and documentation only — no executable code paths changed
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
